### PR TITLE
Fix ISO 8601 year formatting for years < 1000

### DIFF
--- a/src/z_convert.erl
+++ b/src/z_convert.erl
@@ -278,10 +278,8 @@ to_time(L) when is_list(L) ->
 
 %% @doc Convert a datetime (in universal time) to an ISO time string.
 -spec to_isotime(calendar:datetime()) -> string().
-to_isotime(DateTime={D,_}) when D < {1970, 1, 1}->
-    to_list(z_dateformat:format(DateTime, "Y-m-d\\TH:i:s\\Z", en));
 to_isotime(DateTime) ->
-    to_list(z_dateformat:format(DateTime, "Y-m-d\\TH:i:s\\Z", en)).
+    to_list(z_dateformat:format(DateTime, "x-m-d\\TH:i:s\\Z", en)).
 
 
 %%

--- a/src/z_dateformat.erl
+++ b/src/z_dateformat.erl
@@ -305,11 +305,12 @@ tag_to_value($w, Date, _, _Options) ->
 tag_to_value($W, {Y,M,D}, _, _Options) ->
    integer_to_list(year_weeknum(Y,M,D));
 
-% Year with 4 digits, padded with zeroes (e.g. '0003')
-tag_to_value($x, {Y, _, _}, _, _Options) when Y < 0 ->
-    lists:flatten(io_lib:format("-~4..0B", [abs(Y)]));
+% Year with at least 4 digits, padded with zeroes (e.g. '0003')
+tag_to_value($x, {Y, M, D}, T, Options) when Y < 0 ->
+    "-" ++ tag_to_value($x, {abs(Y), M, D}, T, Options);
 tag_to_value($x, {Y, _, _}, _, _Options) ->
-    lists:flatten(io_lib:format("~4..0B", [Y]));
+    Length = integer_to_list(max(4, length(integer_to_list(Y)))),
+    lists:flatten(io_lib:format("~" ++ Length ++ "..0B", [Y]));
 
 % Year, 2 digits; e.g. '99'
 tag_to_value($y, {Y, _, _}, _, _Options) ->

--- a/src/z_dateformat.erl
+++ b/src/z_dateformat.erl
@@ -305,22 +305,26 @@ tag_to_value($w, Date, _, _Options) ->
 tag_to_value($W, {Y,M,D}, _, _Options) ->
    integer_to_list(year_weeknum(Y,M,D));
 
-% Year with at least 4 digits, padded with zeroes (e.g. '0003')
+% Absolute year with at least 4 digits, padded with zeroes (e.g. '0003')
 tag_to_value($x, {Y, _, _}, _, _Options) when Y >= 1000; Y =< -1000 ->
-    integer_to_list(Y);
+    integer_to_list(erlang:abs(Y));
 tag_to_value($x, {Y, _, _}, _, _Options) when Y < 0 ->
-    lists:flatten(io_lib:format("~4..0B", [abs(Y)]));
+    io_lib:format("~4..0B", [0 - Y]);
 tag_to_value($x, {Y, _, _}, _, _Options) ->
-    lists:flatten(io_lib:format("~4..0B", [Y]));
+    io_lib:format("~4..0B", [Y]);
 
 % Year, 2 digits; e.g. '99'
 tag_to_value($y, {Y, _, _}, _, _Options) ->
    Y1 = Y rem 100,
    [ Y1 div 10 + $0, Y1 rem 10 + $0];
 
-% Year, 4 digits; e.g. '1999'
-tag_to_value($Y, {Y, _, _}, _, _Options) ->
+% Year, (at least) 4 digits; e.g. '1999' or '-4150'
+tag_to_value($Y, {Y, _, _}, _, _Options) when Y >= 1000; Y =< -1000 ->
     integer_to_list(Y);
+tag_to_value($Y, {Y, _, _}, _, _Options) when Y < 0 ->
+    [$-, io_lib:format("~4..0B", [0 - Y]) ];
+tag_to_value($Y, {Y, _, _}, _, _Options) ->
+    io_lib:format("~4..0B", [Y]);
 
 % Day of the year; i.e. '0' to '365'
 tag_to_value($z, {Y,M,D}, _, _Options) ->
@@ -364,7 +368,7 @@ year_weeknum(Y,M,D) ->
               _ -> Wk
             end
     end.
-   
+
 weeks_in_year(Y) ->
     D1 = calendar:day_of_the_week(Y, 1, 1),
     D2 = calendar:day_of_the_week(Y, 12, 31),

--- a/src/z_dateformat.erl
+++ b/src/z_dateformat.erl
@@ -41,6 +41,7 @@
     C =:= $U orelse
     C =:= $w orelse
     C =:= $W orelse
+    C =:= $x orelse
     C =:= $y orelse
     C =:= $Y orelse
     C =:= $z orelse
@@ -172,10 +173,10 @@ tag_to_value($c, Date, Time, Options) ->
     {Mins, Sign} = case DiffMins < 0 of
         true -> {0-DiffMins, $-};
         false -> {DiffMins, $+}
-    end,    
+    end,
     Hours   = Mins div 60,
     Minutes = Mins rem 60,
-    replace_tags(Date, Time, "Y-m-d", Options) 
+    replace_tags(Date, Time, "Y-m-d", Options)
         ++ [$T | replace_tags(Date, Time, "H:i:s", Options)]
         ++ [Sign|integer_to_list_zerofill(Hours)]
         ++ [$:|integer_to_list_zerofill(Minutes)];
@@ -289,7 +290,7 @@ tag_to_value($T, Date, Time, Options) ->
 
 % Seconds since the Unix epoch (January 1 1970 00:00:00 GMT)
 tag_to_value($U, Date, Time, Options) ->
-    UtcTime = to_utc({Date, Time}, Options), 
+    UtcTime = to_utc({Date, Time}, Options),
     EpochSecs = calendar:datetime_to_gregorian_seconds(UtcTime)
                 - 62167219200, % calendar:datetime_to_gregorian_seconds({{1970,1,1},{0,0,0}}),
     integer_to_list(EpochSecs);
@@ -304,6 +305,12 @@ tag_to_value($w, Date, _, _Options) ->
 tag_to_value($W, {Y,M,D}, _, _Options) ->
    integer_to_list(year_weeknum(Y,M,D));
 
+% Year with 4 digits, padded with zeroes (e.g. '0003')
+tag_to_value($x, {Y, _, _}, _, _Options) when Y < 0 ->
+    lists:flatten(io_lib:format("-~4..0B", [abs(Y)]));
+tag_to_value($x, {Y, _, _}, _, _Options) ->
+    lists:flatten(io_lib:format("~4..0B", [Y]));
+
 % Year, 2 digits; e.g. '99'
 tag_to_value($y, {Y, _, _}, _, _Options) ->
    Y1 = Y rem 100,
@@ -311,7 +318,7 @@ tag_to_value($y, {Y, _, _}, _, _Options) ->
 
 % Year, 4 digits; e.g. '1999'
 tag_to_value($Y, {Y, _, _}, _, _Options) ->
-   integer_to_list(Y);
+    integer_to_list(Y);
 
 % Day of the year; i.e. '0' to '365'
 tag_to_value($z, {Y,M,D}, _, _Options) ->
@@ -343,7 +350,7 @@ hour_24to12(H) when H < 13 -> H;
 hour_24to12(H) when H < 24 -> H - 12;
 hour_24to12(H) -> H.
 
-year_weeknum(Y,M,D) -> 
+year_weeknum(Y,M,D) ->
     First = (calendar:day_of_the_week(Y, 1, 1) rem 7) - 1,
     Wk = ((((calendar:date_to_gregorian_days(Y, M, D) -
             calendar:date_to_gregorian_days(Y, 1, 1)) + First) div 7)
@@ -386,7 +393,7 @@ tzoffset(LTime, Options) ->
 tzoffset_1(LTime, LTime) ->
     0;
 tzoffset_1(LTime, UTime) ->
-    DiffSecs = calendar:datetime_to_gregorian_seconds(LTime) - 
+    DiffSecs = calendar:datetime_to_gregorian_seconds(LTime) -
        calendar:datetime_to_gregorian_seconds(UTime),
     DiffSecs div 60.
 
@@ -394,7 +401,7 @@ tz_name(Date, Disambiguate, ToTZ) ->
     case localtime:tz_name(Date, ToTZ) of
         {ShortName, _} when is_list(ShortName) ->
             ShortName;
-        {{ShortStandard,_},{ShortDST,_}} -> 
+        {{ShortStandard,_},{ShortDST,_}} ->
             case Disambiguate of
                 prefer_standard -> ShortStandard;
                 prefer_daylight -> ShortDST;

--- a/src/z_dateformat.erl
+++ b/src/z_dateformat.erl
@@ -318,13 +318,9 @@ tag_to_value($y, {Y, _, _}, _, _Options) ->
    Y1 = Y rem 100,
    [ Y1 div 10 + $0, Y1 rem 10 + $0];
 
-% Year, (at least) 4 digits; e.g. '1999' or '-4150'
-tag_to_value($Y, {Y, _, _}, _, _Options) when Y >= 1000; Y =< -1000 ->
-    integer_to_list(Y);
-tag_to_value($Y, {Y, _, _}, _, _Options) when Y < 0 ->
-    [$-, io_lib:format("~4..0B", [0 - Y]) ];
+% Complete year: e.g. '2018', '-15038', or '333'
 tag_to_value($Y, {Y, _, _}, _, _Options) ->
-    io_lib:format("~4..0B", [Y]);
+    integer_to_list(Y);
 
 % Day of the year; i.e. '0' to '365'
 tag_to_value($z, {Y,M,D}, _, _Options) ->

--- a/src/z_dateformat.erl
+++ b/src/z_dateformat.erl
@@ -307,9 +307,9 @@ tag_to_value($W, {Y,M,D}, _, _Options) ->
 
 % Absolute year with at least 4 digits, padded with zeroes (e.g. '0003')
 tag_to_value($x, {Y, _, _}, _, _Options) when Y >= 1000; Y =< -1000 ->
-    integer_to_list(erlang:abs(Y));
+    integer_to_list(Y);
 tag_to_value($x, {Y, _, _}, _, _Options) when Y < 0 ->
-    io_lib:format("~4..0B", [0 - Y]);
+    io_lib:format("-~4..0B", [abs(Y)]);
 tag_to_value($x, {Y, _, _}, _, _Options) ->
     io_lib:format("~4..0B", [Y]);
 

--- a/src/z_dateformat.erl
+++ b/src/z_dateformat.erl
@@ -306,11 +306,12 @@ tag_to_value($W, {Y,M,D}, _, _Options) ->
    integer_to_list(year_weeknum(Y,M,D));
 
 % Year with at least 4 digits, padded with zeroes (e.g. '0003')
-tag_to_value($x, {Y, M, D}, T, Options) when Y < 0 ->
-    "-" ++ tag_to_value($x, {abs(Y), M, D}, T, Options);
+tag_to_value($x, {Y, _, _}, _, _Options) when Y >= 1000; Y =< -1000 ->
+    integer_to_list(Y);
+tag_to_value($x, {Y, _, _}, _, _Options) when Y < 0 ->
+    lists:flatten(io_lib:format("~4..0B", [abs(Y)]));
 tag_to_value($x, {Y, _, _}, _, _Options) ->
-    Length = integer_to_list(max(4, length(integer_to_list(Y)))),
-    lists:flatten(io_lib:format("~" ++ Length ++ "..0B", [Y]));
+    lists:flatten(io_lib:format("~4..0B", [Y]));
 
 % Year, 2 digits; e.g. '99'
 tag_to_value($y, {Y, _, _}, _, _Options) ->

--- a/test/z_convert_test.erl
+++ b/test/z_convert_test.erl
@@ -48,4 +48,7 @@ convert_datetime_test() ->
 datetime_to_iso_test() ->
     ?assertEqual("2010-09-02T10:11:56Z", z_convert:to_isotime({{2010,9,2},{10,11,56}})),
     ?assertEqual("2010-09-02T01:01:01Z", z_convert:to_isotime({{2010,9,2},{1,1,1}})),
+    ?assertEqual("2010-09-02T01:01:01Z", z_convert:to_isotime({{2010,9,2},{1,1,1}})),
+    ?assertEqual("0500-09-02T10:11:56Z", z_convert:to_isotime({{500,9,2},{10,11,56}})),
+    ?assertEqual("-0500-09-02T10:11:56Z", z_convert:to_isotime({{-500,9,2},{10,11,56}})),
     ok.

--- a/test/z_dateformat_test.erl
+++ b/test/z_dateformat_test.erl
@@ -1,0 +1,23 @@
+%% @author Marc Worrell <marc@worrell.nl>
+
+-module(z_dateformat_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+dateformat_year_y_test() ->
+    ?assertEqual(<<"-0999">>,  z_dateformat:format({{  -999,1,1},{0,0,0}}, "Y", [])),
+    ?assertEqual(<<"0999">>,   z_dateformat:format({{   999,1,1},{0,0,0}}, "Y", [])),
+    ?assertEqual(<<"-1000">>,  z_dateformat:format({{ -1000,1,1},{0,0,0}}, "Y", [])),
+    ?assertEqual(<<"1000">>,   z_dateformat:format({{  1000,1,1},{0,0,0}}, "Y", [])),
+    ?assertEqual(<<"-10000">>, z_dateformat:format({{-10000,1,1},{0,0,0}}, "Y", [])),
+    ?assertEqual(<<"10000">>,  z_dateformat:format({{ 10000,1,1},{0,0,0}}, "Y", [])),
+    ok.
+
+dateformat_year_x_test() ->
+    ?assertEqual(<<"0100">>,  z_dateformat:format({{  -100,1,1},{0,0,0}}, "x", [])),
+    ?assertEqual(<<"0100">>,  z_dateformat:format({{   100,1,1},{0,0,0}}, "x", [])),
+    ?assertEqual(<<"10000">>, z_dateformat:format({{-10000,1,1},{0,0,0}}, "x", [])),
+    ?assertEqual(<<"10000">>, z_dateformat:format({{ 10000,1,1},{0,0,0}}, "x", [])),
+    ok.
+

--- a/test/z_dateformat_test.erl
+++ b/test/z_dateformat_test.erl
@@ -15,9 +15,8 @@ dateformat_year_y_test() ->
     ok.
 
 dateformat_year_x_test() ->
-    ?assertEqual(<<"0100">>,  z_dateformat:format({{  -100,1,1},{0,0,0}}, "x", [])),
-    ?assertEqual(<<"0100">>,  z_dateformat:format({{   100,1,1},{0,0,0}}, "x", [])),
-    ?assertEqual(<<"10000">>, z_dateformat:format({{-10000,1,1},{0,0,0}}, "x", [])),
-    ?assertEqual(<<"10000">>, z_dateformat:format({{ 10000,1,1},{0,0,0}}, "x", [])),
+    ?assertEqual(<<"-0100">>,  z_dateformat:format({{  -100,1,1},{0,0,0}}, "x", [])),
+    ?assertEqual(<<"0100">>,   z_dateformat:format({{   100,1,1},{0,0,0}}, "x", [])),
+    ?assertEqual(<<"-10000">>, z_dateformat:format({{-10000,1,1},{0,0,0}}, "x", [])),
+    ?assertEqual(<<"10000">>,  z_dateformat:format({{ 10000,1,1},{0,0,0}}, "x", [])),
     ok.
-

--- a/test/z_dateformat_test.erl
+++ b/test/z_dateformat_test.erl
@@ -6,8 +6,8 @@
 
 
 dateformat_year_y_test() ->
-    ?assertEqual(<<"-0999">>,  z_dateformat:format({{  -999,1,1},{0,0,0}}, "Y", [])),
-    ?assertEqual(<<"0999">>,   z_dateformat:format({{   999,1,1},{0,0,0}}, "Y", [])),
+    ?assertEqual(<<"-999">>,   z_dateformat:format({{  -999,1,1},{0,0,0}}, "Y", [])),
+    ?assertEqual(<<"999">>,    z_dateformat:format({{   999,1,1},{0,0,0}}, "Y", [])),
     ?assertEqual(<<"-1000">>,  z_dateformat:format({{ -1000,1,1},{0,0,0}}, "Y", [])),
     ?assertEqual(<<"1000">>,   z_dateformat:format({{  1000,1,1},{0,0,0}}, "Y", [])),
     ?assertEqual(<<"-10000">>, z_dateformat:format({{-10000,1,1},{0,0,0}}, "Y", [])),


### PR DESCRIPTION
We now have:

```erlang
1> z_convert:to_isotime({{3,1,2}, {12,0,0}}).
"3-01-02T12:00:00Z"
```

That single `3` seems incorrect. In [ISO 8601](https://www.loc.gov/standards/datetime/ISO_DIS%208601-1.pdf):

> calendar year is, unless specified otherwise, represented by four
  digits.

So the year 3 should be written as `0003`.

I left out the following considerations, which don’t seem relevant here:
- the year element can be _expanded_ to include more digits
- the fact that years with less than 4 digits are pre-Gregorian and thus not automatically supported by ISO 8601
- we don’t support _reduced precision_ (4.1.2.3), in which 20th century   can be written as simply `19`.

View this PR without whitespace changes at https://github.com/zotonic/z_stdlib/pull/30/files?w=1