### PR TITLE
HTML sanitizer: ensure a li-element is surrounded by a ul or ol.

### DIFF
--- a/src/z_html.erl
+++ b/src/z_html.erl
@@ -529,11 +529,16 @@ sanitize(ParseTree, ExtraElts, ExtraAttrs, Options) when is_binary(ExtraAttrs) -
 sanitize(ParseTree, ExtraElts, ExtraAttrs, Options) ->
     sanitize(ParseTree, [], ExtraElts, ExtraAttrs, Options).
 
+sanitize({<<"li">>, _, _} = Elt, [], ExtraElts, ExtraAttrs, Options) ->
+    sanitize({<<"ul">>, [], [ Elt ]}, [], ExtraElts, ExtraAttrs, Options);
+sanitize({<<"li">>, _, _} = Elt, [ParentElt | _ ] = Stack, ExtraElts, ExtraAttrs, Options)
+    when ParentElt =/= <<"ul">>, ParentElt =/= <<"ol">> ->
+    sanitize({<<"ul">>, [], [ Elt ]}, Stack, ExtraElts, ExtraAttrs, Options);
 sanitize(B, Stack, _ExtraElts, _ExtraAttrs, Options) when is_binary(B) ->
     case sanitize_element({'TextNode', B}, Stack, Options) of
         {'TextNode', B1} -> escape(iolist_to_binary(B1));
         Other -> Other
-    end; 
+    end;
 sanitize({comment, _Text} = Comment, Stack, _ExtraElts, _ExtraAttrs, Options) ->
     sanitize_element(Comment, Stack, Options);
 sanitize({pi, _Raw}, _Stack, _ExtraElts, _ExtraAttrs, _Options) ->

--- a/test/z_html_test.erl
+++ b/test/z_html_test.erl
@@ -131,6 +131,20 @@ sanitize_test() ->
     % Spaces after mailto:
     ?assertEqual(<<"<a href=\"mailto:jan@example.com\">a</a>">>, 
         z_html:sanitize(<<"<a href=\"mailto: jan@example.com\">a</a>">>)),
+
+    % li without surround ul/ol
+    ?assertEqual(<<"<ul><li>a</li></ul>">>,
+        z_html:sanitize(<<"<li>a</li>">>)),
+
+    ?assertEqual(<<"<div><ul><li>a</li></ul></div>">>,
+        z_html:sanitize(<<"<div><li>a</li></div>">>)),
+
+    ?assertEqual(<<"<ul><li>a</li></ul>">>,
+        z_html:sanitize(<<"<ul><li>a</li></ul>">>)),
+
+    ?assertEqual(<<"<ol><li>a</li></ol>">>,
+        z_html:sanitize(<<"<ol><li>a</li></ol>">>)),
+
     ok.
 
 


### PR DESCRIPTION
Ensure that every `<li>` has an `ul` or `ol` element as parent.