### PR TITLE
Add z_binary module with join function

### DIFF
--- a/src/z_binary.erl
+++ b/src/z_binary.erl
@@ -1,0 +1,35 @@
+%% @author Linus Schoemaker
+%% @copyright Copyright (c) 2018 Linus Schoemaker
+%%
+%% @doc Utility functions for dealing with binaries
+
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(z_binary).
+-author("Linus Schoemaker <de.linus@gmail.com>").
+
+-export([
+         join/2
+        ]).
+
+%% @doc Turn a list of binarys into a single binary separated by the given separator
+%%      Example:
+%%        z_binary:join([<<"foo">>, <<"bar">>], <<",">>) = <<"foo,bar"">>
+-spec join([binary()], binary()) -> binary().
+join(List, Sep) ->
+    SepSize = byte_size(Sep),
+    Result =
+        lists:foldr(fun(Bin, Acc) ->
+                            <<Bin/binary, Sep/binary, Acc/binary>>
+                    end, <<>>, List),
+    binary:part(Result, 0, byte_size(Result) - SepSize).

--- a/src/z_binary.erl
+++ b/src/z_binary.erl
@@ -22,7 +22,7 @@
          join/2
         ]).
 
-%% @doc Turn a list of binarys into a single binary separated by the given separator
+%% @doc Turn a list of binaries into a single binary separated by the given separator
 %%      Example:
 %%        z_binary:join([<<"foo">>, <<"bar">>], <<",">>) = <<"foo,bar"">>
 -spec join([binary()], binary()) -> binary().

--- a/src/z_binary.erl
+++ b/src/z_binary.erl
@@ -32,4 +32,11 @@ join(List, Sep) ->
         lists:foldr(fun(Bin, Acc) ->
                             <<Bin/binary, Sep/binary, Acc/binary>>
                     end, <<>>, List),
-    binary:part(Result, 0, byte_size(Result) - SepSize).
+    ResultSize = byte_size(Result),
+    case SepSize > ResultSize of
+        true ->
+            binary:part(Result, 0,  ResultSize - SepSize);
+        %% This should only happen when `List` is empty
+        false ->
+            Result
+    end.

--- a/src/z_binary.erl
+++ b/src/z_binary.erl
@@ -34,9 +34,9 @@ join(List, Sep) ->
                     end, <<>>, List),
     ResultSize = byte_size(Result),
     case SepSize > ResultSize of
-        true ->
+        false ->
             binary:part(Result, 0,  ResultSize - SepSize);
         %% This should only happen when `List` is empty
-        false ->
+        true ->
             Result
     end.

--- a/test/z_binary_test.erl
+++ b/test/z_binary_test.erl
@@ -1,0 +1,11 @@
+%% @author Linus Schoemaker <linus@driebit.nl>
+
+-module(z_binary_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+join_test() ->
+    ?assertEqual(<<"aap noot mies">>, z_binary:join([<<"aap">>, <<"noot">>, <<"mies">>], <<" ">>)),
+    ?assertEqual(<<"foobarbaz">>, z_binary:join([<<"foo">>, <<"bar">>, <<"baz">>], <<>>)),
+    ?assertEqual(<<>>, z_binary:join([], <<>>)),
+    ?assertEqual(<<>>, z_binary:join([], <<"foo">>)).


### PR DESCRIPTION
We at Driebit are still running Erlang 18, which does not include a binary join function in its standard libary. I've added one here for convenience. 