### PR TITLE
Wip ubf encode options

### DIFF
--- a/test/z_ubf_test.erl
+++ b/test/z_ubf_test.erl
@@ -39,6 +39,13 @@ proplist_test() ->
     ?assertEqual(L, L1),
     ?assertEqual(Enc, <<"#{'b',2}&{'a',1}&`plist`$">>).
 
+recordlist_test() ->
+    L = [{a,1},{b,2},{a,3},{b,4}],
+    {ok, Enc} = z_ubf:encode(L, [{record_names, [a, b]}]),
+    {ok, L1, _} = z_ubf:decode(Enc),
+    ?assertEqual(L, L1),
+    ?assertEqual(<<"#{'b',4}&{'a',3}&{'b',2}&{'a',1}&$">>, Enc).
+
 % bug_test() ->
 %  %% TODO: this was on the original code as a bug/0 function. 
 %    %% was never called, but points to a bug.

--- a/test/z_ubf_test.erl
+++ b/test/z_ubf_test.erl
@@ -38,3 +38,11 @@ proplist_test() ->
     {ok, L1, _} = z_ubf:decode(Enc),
     ?assertEqual(L, L1),
     ?assertEqual(Enc, <<"#{'b',2}&{'a',1}&`plist`$">>).
+
+% bug_test() ->
+%  %% TODO: this was on the original code as a bug/0 function. 
+%    %% was never called, but points to a bug.
+%    C = z_ubf:decode("{'abc"),
+%    z_ubf:decode("d'}$", C).
+
+


### PR DESCRIPTION
This PR adds the possibility to pass a list of record names to `ubf:encode/2`. This list will then be used by the encoder to decide when a list is a proplist or not. The problem now is that if you fill a list with records which have one entry, the decoder will think it is a proplist. The javascript decoder will then try to make keys from the records (objects).

Usage

```erlang

{ok, UBFEncoded} = ubf:encode(Stuff, [{record_names, [insert, copy, skip]}]),
```
The `Options` parameter which is now wired through allows for more custimization in the future.

I also added removed some unused code `bug/0` and moved that to a commented test case. (It actually points to a bug). 

And removed the export all and the import statement.