### PR TITLE
Fix HTML sanitizer crash.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,8 +6,10 @@ ERLC      ?= $(ERL)c
 REBAR := ./rebar3
 REBAR_URL := https://s3.amazonaws.com/rebar3/rebar3
 REBAR_OPTS ?=
+
 # Default target - update sources and call all compile rules in succession
 .PHONY: all
+
 all: compile
 
 $(REBAR):
@@ -36,6 +38,7 @@ xref: $(REBAR)
 
 test: $(REBAR)
 	$(REBAR) as test ct
+	$(REBAR) as test eunit
 
 
 # Cleaning

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,9 @@
-REBAR := ./rebar
-REBAR_URL := https://github.com/rebar/rebar/wiki/rebar
-ERL       ?= erl
+GNUMAKE?= gmake
 
-.PHONY: compile test
+all:
+	${GNUMAKE} $@
 
-all: compile
+.DEFAULT:
+	${GNUMAKE} $@
 
-compile: $(REBAR)
-	$(REBAR) get-deps compile
-
-test: $(REBAR)
-	$(REBAR) -C rebar.test.config get-dep compile
-	$(REBAR) -C rebar.test.config eunit -v skip_deps=true
-
-clean: $(REBAR)
-	$(REBAR) clean
-
-./rebar:
-	$(ERL) -noshell -s inets -s ssl \
-	  -eval '{ok, saved_to_file} = httpc:request(get, {"$(REBAR_URL)", []}, [], [{stream, "./rebar"}])' \
-	  -s init stop
-	chmod +x ./rebar
+.PHONY: all

--- a/src/z_svg.erl
+++ b/src/z_svg.erl
@@ -43,9 +43,13 @@ sanitize(Svg) when is_binary(Svg) ->
     sanitize_1(Svg).
 
 sanitize_1(Svg) ->
-    Parsed = z_html_parse:parse(Svg),
-    Sanitized = sanitize_element(Parsed),
-    flatten(Sanitized).
+    case z_html_parse:parse(Svg) of
+        {ok, Parsed} ->
+            Sanitized = sanitize_element(Parsed),
+            flatten(Sanitized);
+        {error, _} ->
+            <<>>
+    end.
 
 %% @doc Sanitize an element from the SVG parse tree. Also called from z_html.erl
 -spec sanitize_element(svg_element()|term()) -> svg_element(). 

--- a/src/z_url_metadata.erl
+++ b/src/z_url_metadata.erl
@@ -189,24 +189,28 @@ is_index_page(Url) ->
         _ ->
             false
     end.
-    
+
 html_meta(Data) ->
     html_meta(true, Data).
 
 html_meta(true, PartialData) ->
-    Parsed = parse(PartialData),
-    lists:reverse(html(Parsed, [], #ps{}));
+    case parse(PartialData) of
+        {ok, Parsed} ->
+            lists:reverse(html(Parsed, [], #ps{}));
+        {error, _} ->
+            []
+    end;
 html_meta(false, _PartialData) ->
     [].
-    
+
 parse(PartialData) when is_binary(PartialData) ->
-    parse_html(<<"<partial>", PartialData/binary, "</partial>">>);   
+    parse_html(<<"<partial>", PartialData/binary, "</partial>">>);
 parse(PartialData) when is_list(PartialData) ->
     parse_html(iolist_to_binary([<<"<partial>">>, PartialData, <<"</partial>">>])).
-    
+
 parse_html(Html) ->
     z_html_parse:parse(Html).
-    
+
 
 html([], MD, _P) ->
     MD;

--- a/test/z_html_test.erl
+++ b/test/z_html_test.erl
@@ -50,6 +50,9 @@ abs_links_test() ->
                          <<"http://example.com/a/b/d.html">>)),
     ok.
 
+nonhtml_test() ->
+    ?assertEqual({error, nohtml}, z_html_parse:parse(<<"<??/N>">>)),
+    ok.
 
 unescape_test() ->
 	?assertEqual(<<"<>">>, z_html:unescape(<<"&lt;&gt;">>)),


### PR DESCRIPTION
Fix #42

 * Fix crash when parsing `<??/N>`
 * Change return format of z_html_parse:parse/1
 * Add type specs for dialyzer.
 * Let Makefile use GNUMakefile
 * Add eunit test to GNUMakefile