### PR TITLE
OTP 24 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [22,23.2.5]
+        otp_version: [22.3,23.2.5,24.0.1]
         os: [ubuntu-latest]
 
     container:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ all: compile
 
 $(REBAR):
 	$(ERL) -noshell -s inets -s ssl \
-	  -eval '{ok, saved_to_file} = httpc:request(get, {"$(REBAR_URL)", []}, [], [{stream, "$(REBAR)"}])' \
+	  -eval '{ok, saved_to_file} = httpc:request(get, {"$(REBAR_URL)", []}, [{ssl, [ {verify, verify_none} ]}], [{stream, "$(REBAR)"}])' \
 	  -s init stop
 	chmod +x $(REBAR)
 

--- a/rebar.config
+++ b/rebar.config
@@ -9,9 +9,14 @@
  ]
 }.
 
+{deps, [
+    {cowlib, "2.11.0"}
+]}.
+
 {profiles, [
     {test, [
         {deps, [
+            {cowlib, "2.11.0"},
             {proper, "1.3.0"},
             {mochiweb, "2.20.1"},
             {eiconv, "1.0.0"},

--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,6 @@
         {deps, [
             {cowlib, "2.11.0"},
             {proper, "1.3.0"},
-            {mochiweb, "2.20.1"},
             {eiconv, "1.0.0"},
             {erlang_localtime, "1.0.0"}
         ]},

--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,8 @@
 }.
 
 {deps, [
-    {cowlib, "2.11.0"}
+    {cowlib, "2.11.0"},
+    {tls_certificate_check, "1.6.0"}
 ]}.
 
 {profiles, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,16 @@
 {"1.2.0",
-[{<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.11.0">>},0}]}.
+[{<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.11.0">>},0},
+ {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.6">>},1},
+ {<<"tls_certificate_check">>,
+  {pkg,<<"tls_certificate_check">>,<<"1.6.0">>},
+  0}]}.
 [
 {pkg_hash,[
- {<<"cowlib">>, <<"0B9FF9C346629256C42EBE1EEB769A83C6CB771A6EE5960BD110AB0B9B872063">>}]},
+ {<<"cowlib">>, <<"0B9FF9C346629256C42EBE1EEB769A83C6CB771A6EE5960BD110AB0B9B872063">>},
+ {<<"ssl_verify_fun">>, <<"CF344F5692C82D2CD7554F5EC8FD961548D4FD09E7D22F5B62482E5AEAEBD4B0">>},
+ {<<"tls_certificate_check">>, <<"661C287FC3F7823F6A299834664A5932AC9D369BEFEC2883172DE0623A4AEA12">>}]},
 {pkg_hash_ext,[
- {<<"cowlib">>, <<"2B3E9DA0B21C4565751A6D4901C20D1B4CC25CBB7FD50D91D2AB6DD287BC86A9">>}]}
+ {<<"cowlib">>, <<"2B3E9DA0B21C4565751A6D4901C20D1B4CC25CBB7FD50D91D2AB6DD287BC86A9">>},
+ {<<"ssl_verify_fun">>, <<"BDB0D2471F453C88FF3908E7686F86F9BE327D065CC1EC16FA4540197EA04680">>},
+ {<<"tls_certificate_check">>, <<"42476E2E40717F09FBF1B559A8A6975B394E46C94BB5EBB043A18269A46401C0">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,1 +1,8 @@
-[].
+{"1.2.0",
+[{<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.11.0">>},0}]}.
+[
+{pkg_hash,[
+ {<<"cowlib">>, <<"0B9FF9C346629256C42EBE1EEB769A83C6CB771A6EE5960BD110AB0B9B872063">>}]},
+{pkg_hash_ext,[
+ {<<"cowlib">>, <<"2B3E9DA0B21C4565751A6D4901C20D1B4CC25CBB7FD50D91D2AB6DD287BC86A9">>}]}
+].

--- a/src/z_css.erl
+++ b/src/z_css.erl
@@ -280,7 +280,7 @@ serialize_simpleselector({hash, _Line, V}) -> V;
 serialize_simpleselector({class, {ident, _Line, V}}) -> [ $., V ];
 serialize_simpleselector({attrib, {ident, _Line, V}, AttrOpVal}) -> [ $[, V, serialize_attr_opval(AttrOpVal), $] ];
 serialize_simpleselector({pseudo, {ident, _Line, V}}) -> [ $:, V ];
-serialize_simpleselector({pseudo, {function, {function, _Line, F}, {ident, _Line, V}}}) -> [ $:, F, V, $) ].
+serialize_simpleselector({pseudo, {function, {function, _LineF, F}, {ident, _LineI, V}}}) -> [ $:, F, V, $) ].
 
 serialize_attr_opval(undefined) -> <<>>;
 serialize_attr_opval({'=', AttrVal}) -> [ $=, serialize_attr_val(AttrVal) ];

--- a/src/z_url.erl
+++ b/src/z_url.erl
@@ -48,23 +48,13 @@
 
 %%% URL ENCODE %%%
 
+-spec url_encode( string() | atom() | float() | integer() | binary() ) -> binary().
 url_encode(S) ->
-    %% @todo possible speedups for binaries
-    mochiweb_util:quote_plus(S).
+    cow_qs:urlencode( z_convert:to_binary(S) ).
 
+-spec url_decode( string() | binary() ) -> binary().
 url_decode(S) ->
-    lists:reverse(url_decode(S, [])).
-
-    url_decode([], Acc) ->
-      Acc;
-    url_decode([$%, A, B|Rest], Acc) ->
-      Ch = erlang:list_to_integer([A, B], 16),
-      url_decode(Rest, [Ch|Acc]);
-    url_decode([$+|Rest], Acc) ->
-      url_decode(Rest, [32|Acc]);
-    url_decode([Ch|Rest], Acc) ->
-      url_decode(Rest, [Ch|Acc]).
-
+    cow_qs:urldecode( z_convert:to_binary(S) ).
 
 %%% URL PATH ENCODE %%%
 
@@ -116,6 +106,7 @@ percent_encode([C|Etc], Encoded) ->
 
 
 %% @doc Naive function to remove the protocol from an Url
+-spec remove_protocol( string() | binary() ) -> string() | binary().
 remove_protocol("://" ++ Rest) -> Rest;
 remove_protocol(":" ++ Rest) -> Rest;
 remove_protocol([_|T]) -> remove_protocol(T);

--- a/src/z_url_fetch.erl
+++ b/src/z_url_fetch.erl
@@ -156,7 +156,7 @@ fetch_partial(Url0, RedirectCount, Max, OutDev, Opts) ->
                 undefined -> [];
                 Auth -> [ {"Authorization", to_list(Auth)} ]
             end,
-            case fetch_stream(start_stream(Url, Headers, Opts), Max, OutDev) of
+            case fetch_stream(start_stream(Host, Url, Headers, Opts), Max, OutDev) of
                 {ok, Result} ->
                     maybe_redirect(Result, Url, RedirectCount, Max, OutDev, Opts);
                 {error, _} = Error ->
@@ -193,7 +193,7 @@ start_stream(Host, Url, Headers, Opts) ->
         true ->
             [ {verify, verify_none} ];
         _ ->
-            tls_certificate_check:options(Host)}
+            tls_certificate_check:options(Host)
     end,
     Timeout = proplists:get_value(timeout, Opts, ?HTTPC_TIMEOUT),
     HttpOptions = [
@@ -206,7 +206,7 @@ start_stream(Host, Url, Headers, Opts) ->
     try
         httpc:request(get,
                       {Url, Headers},
-                      [],
+                      HttpOptions,
                       [ {sync, false}, {body_format, binary}, {stream, {self, once}} ],
                       profile(Url))
     catch

--- a/src/z_url_fetch.erl
+++ b/src/z_url_fetch.erl
@@ -21,7 +21,7 @@
 -author("Marc Worrell <marc@worrell.nl>").
 
 %% Maximum nmber of bytes fetched for metadata extraction
--define(HTTPC_LENGTH, 32*1024).
+-define(HTTPC_LENGTH, 64*1024).
 -define(HTTPC_MAX_LENGTH, 1024*1024*100).  % Max 100MB
 
 %% Number of redirects followed before giving up
@@ -55,7 +55,8 @@
 -type option() :: {device, pid()}
                 | {timeout, pos_integer()}
                 | {max_length, pos_integer()}
-                | {authorization, binary() | string()}.
+                | {authorization, binary() | string()}
+                | insecure.
 
 -export_type([
     options/0,
@@ -139,32 +140,37 @@ fetch_partial(Url0, RedirectCount, _Max, _OutDev, _Opts) when RedirectCount >= ?
     {error, too_many_redirects};
 fetch_partial(Url0, RedirectCount, Max, OutDev, Opts) ->
     httpc_flush(),
-    Url = to_list( normalize_url(Url0) ),
-    Headers = [
-        {"Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"},
-        {"Accept-Encoding", "identity"},
-        {"Accept-Charset", "UTF-8;q=1.0, ISO-8859-1;q=0.5, *;q=0"},
-        {"Accept-Language", "en,*;q=0"},
-        {"User-Agent", httpc_ua(Url)}
-    ] ++ case Max of
-        undefined -> [];
-        _ -> [ {"Range", "bytes=0-"++integer_to_list(Max-1)} ]
-    end ++ case proplists:get_value(authorization, Opts) of
-        undefined -> [];
-        Auth -> [ {"Authorization", to_list(Auth)} ]
-    end,
-    case fetch_stream(start_stream(Url, Headers, Opts), Max, OutDev) of
-        {ok, Result} ->
-            maybe_redirect(Result, Url, RedirectCount, Max, OutDev, Opts);
+    case normalize_url(Url0) of
+        {ok, {Host, UrlBin}} ->
+            Url = to_list(UrlBin),
+            Headers = [
+                {"Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"},
+                {"Accept-Encoding", "identity"},
+                {"Accept-Charset", "UTF-8;q=1.0, ISO-8859-1;q=0.5, *;q=0"},
+                {"Accept-Language", "en,*;q=0"},
+                {"User-Agent", httpc_ua(Url)}
+            ] ++ case Max of
+                undefined -> [];
+                _ -> [ {"Range", "bytes=0-"++integer_to_list(Max-1)} ]
+            end ++ case proplists:get_value(authorization, Opts) of
+                undefined -> [];
+                Auth -> [ {"Authorization", to_list(Auth)} ]
+            end,
+            case fetch_stream(start_stream(Url, Headers, Opts), Max, OutDev) of
+                {ok, Result} ->
+                    maybe_redirect(Result, Url, RedirectCount, Max, OutDev, Opts);
+                {error, _} = Error ->
+                    error_logger:warning_msg("Error fetching url ~p error: ~p", [Url, Error]),
+                    Error
+            end;
         {error, _} = Error ->
-            error_logger:warning_msg("Error fetching url ~p error: ~p", [Url, Error]),
             Error
     end.
 
 to_list(B) when is_binary(B) -> binary_to_list(B);
 to_list(L) when is_list(L) -> L.
 
--spec normalize_url(string() | binary()) -> binary().
+-spec normalize_url(string() | binary()) -> {ok, {binary(), binary()}} | {error, url}.
 normalize_url(Url) ->
     case uri_string:parse(z_convert:to_binary(Url)) of
         #{
@@ -176,19 +182,31 @@ normalize_url(Url) ->
                 <<>> -> <<>>;
                 Q -> <<"?", Q/binary>>
             end,
-            iolist_to_binary([
-                Scheme, "://", Host, Path, Query
-                ]);
+            Url1 = iolist_to_binary([ Scheme, "://", Host, Path, Query ]),
+            {ok, {Host, Url1}};
         _ ->
-            <<>>
+            {error, url}
     end.
 
-start_stream(Url, Headers, Opts) ->
+start_stream(Host, Url, Headers, Opts) ->
+    SSLOptions = case proplists:get_value(insecure, Opts) of
+        true ->
+            [ {verify, verify_none} ];
+        _ ->
+            tls_certificate_check:options(Host)}
+    end,
+    Timeout = proplists:get_value(timeout, Opts, ?HTTPC_TIMEOUT),
+    HttpOptions = [
+        {autoredirect, false},
+        {relaxed, true},
+        {timeout, Timeout},
+        {connect_timeout, ?HTTPC_TIMEOUT_CONNECT},
+        {ssl, SSLOptions}
+     ],
     try
-        Timeout = proplists:get_value(timeout, Opts, ?HTTPC_TIMEOUT),
         httpc:request(get,
                       {Url, Headers},
-                      [ {autoredirect, false}, {relaxed, true}, {timeout, Timeout}, {connect_timeout, ?HTTPC_TIMEOUT_CONNECT} ],
+                      [],
                       [ {sync, false}, {body_format, binary}, {stream, {self, once}} ],
                       profile(Url))
     catch

--- a/src/zotonic_stdlib.app.src
+++ b/src/zotonic_stdlib.app.src
@@ -2,7 +2,7 @@
     {description, "Zotonic standard library"},
     {vsn, "git"},
     {registered, []},
-    {applications, [kernel, stdlib]},
+    {applications, [kernel, stdlib, tls_certificate_check]},
     {env, []},
     {modules, []},
     {maintainers, ["Zotonic Team"]},

--- a/test/z_url_test.erl
+++ b/test/z_url_test.erl
@@ -5,16 +5,16 @@
 -include_lib("eunit/include/eunit.hrl").
 
 url_encode_decode_test() ->
-    Url = "index.html?x=y&z=1",
+    Url = <<"index.html?x=y&z=1">>,
     ?assertEqual(Url, z_url:url_decode(z_url:url_encode(Url))).
 
 
 url_encode_test() ->
-    ?assertEqual("foo+bar", z_url:url_encode("foo bar")),
-    ?assertEqual("foo%26bar", z_url:url_encode("foo&bar")).
+    ?assertEqual(<<"foo+bar">>, z_url:url_encode("foo bar")),
+    ?assertEqual(<<"foo%26bar">>, z_url:url_encode("foo&bar")).
 
 url_decode_test() ->
-    ?assertEqual("foo&bar", z_url:url_decode("foo%26bar")).
+    ?assertEqual(<<"foo&bar">>, z_url:url_decode("foo%26bar")).
 
 
 percent_encode_test() ->


### PR DESCRIPTION
Mochiweb is not OTP24 ready and we only use a small amount of code from mochiweb.

Remove the references to mochiweb, where possible replace with cowlib utils.

Fixes #59 