### PR TITLE
z_html: sanitize recursively on type in keys

### DIFF
--- a/src/z_html.erl
+++ b/src/z_html.erl
@@ -160,7 +160,9 @@ sanitize_list(Ks, L, Options) when is_list(L) ->
                 P1 = z_convert:to_binary(P),
                 V1 = escape_props1(P1, V, Options),
                 {P1, V1};
-            (V) when is_list(V); is_map(V)->
+            (V) when is_list(V), Ks =:= [] ->
+                escape_props(V, Options);
+            (V) when is_map(V)->
                 escape_props(V, Options);
             (V) when Ks =:= [] ->
                 escape_value(V);

--- a/src/z_html.erl
+++ b/src/z_html.erl
@@ -162,7 +162,7 @@ sanitize_list(Ks, L, Options) when is_list(L) ->
                 {P1, V1};
             (V) when is_list(V), Ks =:= [] ->
                 escape_props(V, Options);
-            (V) when is_map(V)->
+            (V) when is_map(V) ->
                 escape_props(V, Options);
             (V) when Ks =:= [] ->
                 escape_value(V);

--- a/test/z_html_test.erl
+++ b/test/z_html_test.erl
@@ -34,6 +34,13 @@ escape_props_1_test() ->
         <<"foo_id_list">> => [ 1, 2, <<"foo&amp;bar">>, undefined ]
     },
     ?assertEqual(Ps2Out, z_html:escape_props(Ps2)),
+    Ps3 = #{
+        <<"foo_id_list_list">> => [ [ <<"1">>, <<"2">> ], [ <<"foo&bar">>, <<>> ] ]
+    },
+    Ps3Out = #{
+        <<"foo_id_list_list">> => [ [ 1, 2 ], [ <<"foo&amp;bar">>, undefined ] ]
+    },
+    ?assertEqual(Ps3Out, z_html:escape_props(Ps3)),
     ok.
 
 ensure_check_test() ->

--- a/test/z_html_test.erl
+++ b/test/z_html_test.erl
@@ -19,6 +19,23 @@ escape_props_test() ->
                  z_html:escape_props([{body, <<"Foo & bar">>}])),
     ok.
 
+escape_props_1_test() ->
+    Ps1 = #{
+        <<"foo_int_list">> => [ <<"1">>, <<"2">> ]
+    },
+    Ps1Out = #{
+        <<"foo_int_list">> => [ 1, 2 ]
+    },
+    ?assertEqual(Ps1Out, z_html:escape_props(Ps1)),
+    Ps2 = #{
+        <<"foo_id_list">> => [ <<"1">>, <<"2">>, <<"foo&bar">>, <<>> ]
+    },
+    Ps2Out = #{
+        <<"foo_id_list">> => [ 1, 2, <<"foo&amp;bar">>, undefined ]
+    },
+    ?assertEqual(Ps2Out, z_html:escape_props(Ps2)),
+    ok.
+
 ensure_check_test() ->
 	?assertEqual(<<"&#1234; &lt;&gt;;">>, z_html:escape_check(<<"&#1234; <>;">>)),
 	ok.


### PR DESCRIPTION
This allows the sanitization of values like:

```erlang
    Ps3 = #{
        <<"foo_id_list_list">> => [ [ <<"1">>, <<"2">> ], [ <<"foo&bar">>, <<>> ] ]
    },
    Ps3Out = #{
        <<"foo_id_list_list">> => [ [ 1, 2 ], [ <<"foo&amp;bar">>, undefined ] ]
    },
    ?assertEqual(Ps3Out, z_html:escape_props(Ps3)),
```
