### PR TITLE
z_url_metadata: fetch more data for metadata extraction.

### DIFF
--- a/src/z_url_fetch.erl
+++ b/src/z_url_fetch.erl
@@ -72,7 +72,8 @@
 
 -export_type([
     options/0,
-    option/0
+    option/0,
+    fetch_result/0
 ]).
 
 -define(is_method(M), (M =:= get orelse M =:= post orelse M =:= delete orelse M =:= put orelse M =:= patch)).

--- a/src/z_url_metadata.erl
+++ b/src/z_url_metadata.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell
-%% @copyright 2014-2021 Marc Worrell
+%% @copyright 2014-2022 Marc Worrell
 %% @doc Discover metadata about an url.
 
-%% Copyright 2014-2021 Marc Worrell
+%% Copyright 2014-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@
 
 -export_type([ metadata/0 ]).
 
--define(FETCH_LENGTH, 256*1024).
+-define(FETCH_LENGTH, 1024*1024).
 
 %% @doc Fetch metadata information for the URL
 -spec fetch(binary()|string()) -> {ok, metadata()} | {error, term()}.


### PR DESCRIPTION
This is needed for youtube, as the `og:` meta tags appears after > 256KB of head text.

Also export some types from z_url_fetch.