### PR TITLE
z_html: also strip html comments and the content of style/script tags

### DIFF
--- a/src/z_convert.erl
+++ b/src/z_convert.erl
@@ -176,6 +176,7 @@ to_bool_strict(undefined) -> false;
 to_bool_strict(false) -> false;
 to_bool_strict(0) -> false;
 to_bool_strict(0.0) -> false;
+to_bool_strict(-0.0) -> false;
 to_bool_strict(<<>>) -> false;
 to_bool_strict(<<0>>) -> false;
 to_bool_strict([]) -> false;

--- a/src/z_html.erl
+++ b/src/z_html.erl
@@ -634,6 +634,26 @@ strip(<<"</span>",T/binary>>, Acc, N) ->
     strip(T, Acc, N);
 strip(<<"</a>",T/binary>>, Acc, N) ->
     strip(T, Acc, N);
+strip(<<"<script", T/binary>>, Acc, N) ->
+    case binary:split(T, <<"</script">>) of
+        [_] -> Acc;
+        [_, Rest] -> strip_tag(Rest, Acc, N)
+    end;
+strip(<<"<noscript", T/binary>>, Acc, N) ->
+    case binary:split(T, <<"</noscript">>) of
+        [_] -> Acc;
+        [_, Rest] -> strip_tag(Rest, Acc, N)
+    end;
+strip(<<"<style", T/binary>>, Acc, N) ->
+    case binary:split(T, <<"</style">>) of
+        [_] -> Acc;
+        [_, Rest] -> strip_tag(Rest, Acc, N)
+    end;
+strip(<<"<!--",T/binary>>, Acc, N) ->
+    case binary:split(T, <<"-->">>) of
+        [_] -> Acc;
+        [_, Rest] -> strip(Rest, Acc, N)
+    end;
 strip(<<"<",T/binary>>, Acc, N) ->
     strip_tag(T, Acc, N);
 strip(<<H/utf8,T/binary>>, Acc, N) ->

--- a/src/z_mochinum.erl
+++ b/src/z_mochinum.erl
@@ -28,6 +28,8 @@ digits(N) when is_integer(N) ->
     integer_to_list(N);
 digits(0.0) ->
     "0.0";
+digits(-0.0) ->
+    "0.0";
 digits(Float) ->
     {Frac1, Exp1} = frexp_int(Float),
     [Place0 | Digits0] = digits1(Float, Exp1, Frac1),
@@ -269,6 +271,8 @@ digits_test() ->
                  digits(0)),
     ?assertEqual("0.0",
                  digits(0.0)),
+    ?assertEqual("0.0",
+                 digits(-0.0)),
     ?assertEqual("1.0",
                  digits(1.0)),
     ?assertEqual("-1.0",

--- a/test/z_html_test.erl
+++ b/test/z_html_test.erl
@@ -68,6 +68,12 @@ strip_test() ->
     ?assertEqual(<<"1234\n5678">>, z_html:strip(<<"<p>1234\n<span>5678</span></p>">>)),
     ?assertEqual(<<"This is a list item.">>, z_html:strip(<<"<ul><li>This is a list item.</li></ul>">>)),
     ?assertEqual(<<"1234 5678">>, z_html:strip(<<"<p>1234</p><p>5678</p>">>)),
+    ?assertEqual(<<"1234 5678">>, z_html:strip(<<"<p>1234</p><!-- Hello --><p>5678</p>">>)),
+    ?assertEqual(<<"12345678">>, z_html:strip(<<"<p>1234<!-- Hello -->5678</p>">>)),
+    ?assertEqual(<<"1234 5678">>, z_html:strip(<<"<p>1234<style type=\"text/css\">foo: { a: x }</style>5678</p>">>)),
+    ?assertEqual(<<"1234 5678">>, z_html:strip(<<"<p>1234<script type=\"text/javascript\">foo();</script>5678</p>">>)),
+    ?assertEqual(<<"1234 5678">>, z_html:strip(<<"<p>1234<style>foo: { a: x }</style>5678</p>">>)),
+    ?assertEqual(<<"1234 5678">>, z_html:strip(<<"<p>1234<script>foo();</script>5678</p>">>)),
     ok.
 
 abs_links_test() ->

--- a/test/z_html_test.erl
+++ b/test/z_html_test.erl
@@ -74,6 +74,7 @@ strip_test() ->
     ?assertEqual(<<"1234 5678">>, z_html:strip(<<"<p>1234<script type=\"text/javascript\">foo();</script>5678</p>">>)),
     ?assertEqual(<<"1234 5678">>, z_html:strip(<<"<p>1234<style>foo: { a: x }</style>5678</p>">>)),
     ?assertEqual(<<"1234 5678">>, z_html:strip(<<"<p>1234<script>foo();</script>5678</p>">>)),
+    ?assertEqual(<<"1234 5678">>, z_html:strip(<<"<p>1234<noscript>foobar</noscript>5678</p>">>)),
     ok.
 
 abs_links_test() ->


### PR DESCRIPTION
This modifies `z_html:strip` to:

 * skip the data between the open/close of `script`, `noscript` and `style` tags.
 * remove html comments

Also add `-0.0` where needed for OTP27 compatibility.
