### PR TITLE
z_html_sanitize: sanitize data url with svg, export more relaxed uri sanitize

### DIFF
--- a/src/z_dateformat.erl
+++ b/src/z_dateformat.erl
@@ -413,10 +413,19 @@ to_utc(LTime, Options) ->
             UTC
     end.
 
+tzoffset({{Y, _, _}, _}, _Options) when Y < 1916->
+    0;
 tzoffset(LTime, Options) ->
     case proplists:get_value(utc, Options) of
         undefined ->
-            tzoffset_1(LTime, erlang:localtime_to_universaltime(LTime));
+            UTime = case LTime of
+                {{Y, M, D}, T} when Y =< 1 ->
+                    {{Y1, M1, D1}, T1} = erlang:localtime_to_universaltime({{10, M, D}, T}),
+                    {{Y1 - 10 + Y, M1, D1}, T1};
+                _ ->
+                    erlang:localtime_to_universaltime(LTime)
+            end,
+            tzoffset_1(LTime, UTime);
         UTime ->
             tzoffset_1(LTime, UTime)
     end.

--- a/src/z_dateformat.erl
+++ b/src/z_dateformat.erl
@@ -78,6 +78,8 @@ format(FormatString, Options) ->
 -spec format( datetime() | calendar:date(), string(), list() ) -> binary() | undefined.
 format({{9999,_,_},_}, _FormatString, _Options) ->
     undefined;
+format({{0,0,0},{0,0,0}}, _FormatString, _Options) ->
+    undefined;
 format({{_,_,_} = Date,{_,_,_} = Time}, FormatString, Options) ->
     iolist_to_binary(replace_tags(Date, Time, FormatString, Options));
 

--- a/src/z_url.erl
+++ b/src/z_url.erl
@@ -286,7 +286,6 @@ make_abs_link(Url, _Host, HostDir) ->
 
 
 %% @doc Decode a "data:" url to its parts.
-%%      Crashes if the url doesn't have a "data:" protocol.
 -spec decode_data_url(binary()) -> {ok, Mime::binary(), Charset::binary(), Data::binary()} | {error, unknown_encoding}.
 decode_data_url(<<"data:", Data/binary>>) ->
     case binary:split(Data, <<",">>) of

--- a/src/z_url.erl
+++ b/src/z_url.erl
@@ -309,8 +309,9 @@ decode_data_url(<<"data:", Data/binary>>) ->
             MimeParts = binary:split(MimeData, <<";">>, [global]),
             Mime = find_mime(MimeParts),
             Charset = find_charset(MimeParts),
-            DecodedData = case lists:member(<<"base64">>, MimeParts) of
-                true -> decode_base64(EncodedData);
+            DecodedData = case last(MimeParts) of
+                <<"base64">> -> decode_base64(EncodedData);
+                <<"utf8">> -> EncodedData;
                 false -> z_url:url_decode(EncodedData)
             end,
             {ok, Mime, Charset, DecodedData};
@@ -319,6 +320,9 @@ decode_data_url(<<"data:", Data/binary>>) ->
     end;
 decode_data_url(Url) when is_binary(Url) ->
     {error, nodata}.
+
+last([]) -> undefined;
+last(L) -> lists:last(L).
 
 decode_base64(Data) ->
     Data1 = << <<case C of $- -> $+; $_ -> $/; _ -> C end>> || <<C>> <= Data >>,

--- a/src/z_url.erl
+++ b/src/z_url.erl
@@ -312,7 +312,7 @@ decode_data_url(<<"data:", Data/binary>>) ->
             DecodedData = case last(MimeParts) of
                 <<"base64">> -> decode_base64(EncodedData);
                 <<"utf8">> -> EncodedData;
-                false -> z_url:url_decode(EncodedData)
+                _ -> z_url:url_decode(EncodedData)
             end,
             {ok, Mime, Charset, DecodedData};
         [ _ ] ->

--- a/test/z_html_test.erl
+++ b/test/z_html_test.erl
@@ -109,7 +109,6 @@ unescape_test() ->
 
     ok.
 
-
 truncate_test() ->
     ?assertEqual(<<"12345">>, z_html:truncate(<<"12345">>, 6)),
     ?assertEqual(<<"12345">>, z_html:truncate(<<"12345">>, 5)),
@@ -207,6 +206,24 @@ sanitize_test() ->
         z_html:sanitize(<<"<ol><li>a</li></ol>">>)),
 
     ok.
+
+data_url_sanitize_test() ->
+    Url = <<"data:image/gif;base64,R0lGODlhAQABAJAAAAAAAAAAACH5BAEUAAAALAAAAAABAAEAAAICRAEAOw==">>,
+    ?assertEqual(<<>>, z_html:sanitize_uri(Url, false)),
+    ?assertEqual(Url, z_html:sanitize_uri(Url, true)),
+    ok.
+
+data_url_sanitize_svg_test() ->
+    Url = <<"data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22",
+            "400%22%20height%3D%22400%22%20viewBox%3D%220%200%20124%20124%22%20fill%3D%22none%22%3E%3Crect",
+            "%20width%3D%22124%22%20height%3D%22124%22%20rx%3D%2224%22%20fill%3D%22%23F97316%22%2F%3E%3C%2F",
+            "svg%3E">>,
+    Sanitized = <<"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0",
+                  "MDAiIGhlaWdodD0iNDAwIiB2aWV3Qm94PSIwIDAgMTI0IDEyNCIgZmlsbD0ibm9uZSI+PHJlY3Qgd2lkdGg9IjEyNCI",
+                  "gaGVpZ2h0PSIxMjQiIHJ4PSIyNCIgZmlsbD0iI0Y5NzMxNiI+PC9yZWN0Pjwvc3ZnPg==">>,
+    ?assertEqual(Sanitized, z_html:sanitize_uri(Url, true)),
+    ok.
+
 
 rel_sanitize_test() ->
     ?assertEqual(<<"<a rel=\"nofollow noopener noreferrer\" target=\"_blank\" href=\"https://example.com\">Click me</a>">>,


### PR DESCRIPTION
The strict URI sanitizer does not allow any data urls.
With the relaxed version data urls are allowed for media and SVG, and the SVGs are sanitized using the SVG sanitizer.

Also catch "empty" dates in the date formatter, map them to undefined.