### PR TITLE
Add 'rename/2' to z_filelib

### DIFF
--- a/src/z_filelib.erl
+++ b/src/z_filelib.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2017-2021 Marc Worrell
-%%
+%% @copyright 2017-2025 Marc Worrell
 %% @doc Extra file functions.
+%% @end
 
-%% Copyright 2017-2021 Marc Worrell
+%% Copyright 2017-2025 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -20,10 +20,32 @@
 -module(z_filelib).
 
 -export([
+    rename/2,
     ensure_dir/1,
     os_filename/1,
     os_escape/1
     ]).
+
+
+%% @doc Rename a file. Copy the file on a cross-fs error.
+-spec rename(From, To) -> ok | {error, term()} when
+    From :: file:filename_all(),
+    To :: file:filename_all().
+rename(From, To) ->
+    case file:rename(From, To) of
+        ok ->
+            ok;
+        {error, exdev} ->
+            % cross-fs rename is not supported by erlang, so copy and delete the file
+            case file:copy(From, To) of
+                {ok, _BytesCopied} ->
+                    ok = file:delete(From);
+                {error, _} = Error ->
+                    Error
+            end;
+        {error, _} = Error ->
+            Error
+    end.
 
 %% @doc Ensure the directory of a file is present. This will still work
 %%      if a soft-link in the path refers to a missing directory.


### PR DESCRIPTION
This rename takes care of cross-filesystem rename errors.
If a file is renamed cross file systems, then it is copied and then the original is deleted.