### PR TITLE
Sanitizer: remove 'name' attribute from most elements

### DIFF
--- a/src/z_html.erl
+++ b/src/z_html.erl
@@ -1,5 +1,5 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2009-2025 Marc Worrell
+%% @copyright 2009-2026 Marc Worrell
 %% @doc Utility functions sanitizing, escaping and filtering HTML, and sanitize property lists/maps.
 %%
 %% Utiliy functions to:
@@ -13,7 +13,7 @@
 %% - Make relative URLs absolute based on a base URL.
 %% @end
 
-%% Copyright 2009-2025 Marc Worrell
+%% Copyright 2009-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -885,7 +885,7 @@ sanitize({<<"svg">>, _Attrs, _Enclosed} = Element, _Stack, ExtraElts, _ExtraAttr
 sanitize({Elt,Attrs,Enclosed}, Stack, ExtraElts, ExtraAttrs, Options) ->
     case allow_elt(Elt, ExtraElts) orelse (not lists:member(Elt, Stack) andalso allow_once(Elt)) of
         true ->
-            Attrs1 = lists:filter(fun({A,_}) -> allow_attr(A, ExtraAttrs) end, Attrs),
+            Attrs1 = lists:filter(fun({A,_}) -> allow_attr(Elt, A, ExtraAttrs) end, Attrs),
             Stack1 = [Elt|Stack],
             Tag = { Elt, 
                     Attrs1,
@@ -1115,7 +1115,17 @@ allow_elt(<<"wbr">>) -> true;
 allow_elt(_) -> false.
 
 %% @doc Allowed attributes
-allow_attr(Attr, Extra) ->
+allow_attr(Elt, <<"name">>, _Extra)
+    when Elt =:= <<"meta">>;
+         Elt =:= <<"a">>;
+         Elt =:= <<"input">>;
+         Elt =:= <<"select">>;
+         Elt =:= <<"textarea">>;
+         Elt =:= <<"button">> ->
+    % Prevent overriding 'document' properties by named elements.
+    % Exceptions are names on input and anchor elements.
+    true;
+allow_attr(_Elt, Attr, Extra) ->
     allow_attr(Attr) orelse lists:member(Attr, Extra).
 
 allow_attr(<<"align">>) -> true;
@@ -1132,9 +1142,7 @@ allow_attr(<<"coords">>) -> true;
 allow_attr(<<"dir">>) -> true;
 allow_attr(<<"height">>) -> true;
 allow_attr(<<"href">>) -> true;
-%allow_attr(<<"id">>) -> true;
 allow_attr(<<"loop">>) -> true;
-allow_attr(<<"name">>) -> true;
 allow_attr(<<"poster">>) -> true;
 allow_attr(<<"preload">>) -> true;
 allow_attr(<<"rel">>) -> true;

--- a/src/z_html.erl
+++ b/src/z_html.erl
@@ -882,7 +882,17 @@ sanitize({<<"svg">>, _Attrs, _Enclosed} = Element, _Stack, ExtraElts, _ExtraAttr
         false ->
             {nop, []}
     end;
-sanitize({Elt,Attrs,Enclosed}, Stack, ExtraElts, ExtraAttrs, Options) ->
+sanitize({<<"a">>, Attrs, _Enclosed} = E, Stack, ExtraElts, ExtraAttrs, Options) ->
+    case lists:keyfind(<<"name">>, 1, Attrs) of
+        {<<"name">>, _} = Name ->
+            sanitize_1({<<"a">>, [ Name ], []}, Stack, ExtraElts, ExtraAttrs, Options);
+        false ->
+            sanitize_1(E, Stack, ExtraElts, ExtraAttrs, Options)
+    end;
+sanitize({_Elt, _Attrs, _Enclosed} = E, Stack, ExtraElts, ExtraAttrs, Options) ->
+    sanitize_1(E, Stack, ExtraElts, ExtraAttrs, Options).
+
+sanitize_1({Elt, Attrs, Enclosed}, Stack, ExtraElts, ExtraAttrs, Options) ->
     case allow_elt(Elt, ExtraElts) orelse (not lists:member(Elt, Stack) andalso allow_once(Elt)) of
         true ->
             Attrs1 = lists:filter(fun({A,_}) -> allow_attr(Elt, A, ExtraAttrs) end, Attrs),

--- a/test/z_html_test.erl
+++ b/test/z_html_test.erl
@@ -211,6 +211,14 @@ sanitize_test() ->
     ?assertEqual(<<"<ol><li>a</li></ol>">>,
         z_html:sanitize(<<"<ol><li>a</li></ol>">>)),
 
+    % name on img should be removed
+    ?assertEqual(<<"<img src=\"/image/foo.jpg\" />">>,
+        z_html:sanitize(<<"<img name='foo' src='/image/foo.jpg'>">>)),
+
+    % name on a should not be removed
+    ?assertEqual(<<"<a name=\"foo\"></a>">>,
+        z_html:sanitize(<<"<a name='foo'>">>)),
+
     ok.
 
 data_url_sanitize_test() ->

--- a/test/z_html_test.erl
+++ b/test/z_html_test.erl
@@ -217,7 +217,11 @@ sanitize_test() ->
 
     % name on a should not be removed
     ?assertEqual(<<"<a name=\"foo\"></a>">>,
-        z_html:sanitize(<<"<a name='foo'>">>)),
+        z_html:sanitize(<<"<a name='foo' href='#hallo'>">>)),
+
+    % Anchors with name do not have enclosed data
+    ?assertEqual(<<"<a name=\"foo\"></a>">>,
+        z_html:sanitize(<<"<a name='foo'>baz</a>">>)),
 
     ok.
 

--- a/test/z_html_test.erl
+++ b/test/z_html_test.erl
@@ -215,7 +215,7 @@ sanitize_test() ->
     ?assertEqual(<<"<img src=\"/image/foo.jpg\" />">>,
         z_html:sanitize(<<"<img name='foo' src='/image/foo.jpg'>">>)),
 
-    % name on a should not be removed
+    % name on a should be preserved, while href is stripped from a named anchor
     ?assertEqual(<<"<a name=\"foo\"></a>">>,
         z_html:sanitize(<<"<a name='foo' href='#hallo'>">>)),
 


### PR DESCRIPTION
Extend the HTML sanitizer to filter `name` attributes from most elements.

Adding a `name` to (for example) an image tag `<img name=foo>` will set `document.foo`.
That gives a problem if document properties like `currentScript` or `implementation` are used by Javascript code.

Only `name` attributes on the following HTML elements are now allowed:

 * `a`
 * `input`, `select`, `textarea`, `button`
 * `meta`

Note that only `a` is on the default list of allowed elements.

### Copilot description

This pull request updates the HTML sanitization logic in `z_html.erl` to improve attribute filtering, specifically for the `name` attribute, and adds new tests to validate this behavior. The main change ensures that the `name` attribute is only allowed on specific elements, preventing potential issues with overriding document properties.

### HTML attribute filtering improvements

* Changed the `allow_attr/3` function to only allow the `name` attribute on certain elements (`meta`, `a`, `input`, `select`, `textarea`, `button`), rather than allowing it on all elements. This helps prevent unintended overriding of document properties. [[1]](diffhunk://#diff-f700ef23ec49b6ddad2d94a66c96d4b122e8a0aa8809718464670d2064456923L1118-R1128) [[2]](diffhunk://#diff-f700ef23ec49b6ddad2d94a66c96d4b122e8a0aa8809718464670d2064456923L1135-L1137)
* Updated the attribute filtering in the `sanitize` function to use the new `allow_attr/3` signature, passing the element name along with the attribute.

### Testing updates

* Added test cases to ensure that the `name` attribute is removed from `img` elements but retained on `a` elements, verifying the new behavior.

### Documentation and copyright

* Updated copyright years in the file header and comments to 2026. [[1]](diffhunk://#diff-f700ef23ec49b6ddad2d94a66c96d4b122e8a0aa8809718464670d2064456923L2-R2) [[2]](diffhunk://#diff-f700ef23ec49b6ddad2d94a66c96d4b122e8a0aa8809718464670d2064456923L16-R16)