### PR TITLE
CSS sanitizer: add css3 support. Fixes #89

### DIFF
--- a/src/z_css.erl
+++ b/src/z_css.erl
@@ -48,6 +48,7 @@
             | ident
             | hash
             | import_sym
+            | font_face_sym
             | page_sym
             | media_sym
             | charset_sym
@@ -58,6 +59,7 @@
             | angle
             | time
             | freq
+            | resolution
             | dimension
             | percentage
             | number
@@ -72,7 +74,9 @@
 -type charset() :: no_charset
                  | {charset, string()}.
 
--type media() :: [ {ident, line(), string()} ].
+-type media_term() :: token()
+                    | {media_feature, Name::token(), Value::term() | undefined}.
+-type media() :: [ media_term() ].
 -type medialist() :: [ media() ].
 -type import() :: no_import
                 | {import, Uri::token(), medialist()}.
@@ -186,6 +190,7 @@ sanitize_expr({exs, _, _} = E) -> E;
 sanitize_expr({angle, _, _} = E) -> E;
 sanitize_expr({time, _, _} = E) -> E;
 sanitize_expr({freq, _, _} = E) -> E;
+sanitize_expr({resolution, _, _} = E) -> E;
 sanitize_expr({dimension, _, _} = E) -> E;
 sanitize_expr({percentage, _, _} = E) -> E;
 sanitize_expr({string, Line, S}) -> {string, Line, sanitize_string(S)};
@@ -241,7 +246,23 @@ serialize_medialist([M|Rest]) ->
         end
     ].
 
-serialize_media({ident, _, Ident}) -> Ident.
+serialize_media([]) ->
+    [];
+serialize_media([M|Rest]) ->
+    [
+        serialize_media_term(M),
+        case Rest of
+            [] -> [];
+            Ms -> [ 32, serialize_media(Ms) ]
+        end
+    ].
+
+serialize_media_term({ident, _, Ident}) ->
+    Ident;
+serialize_media_term({media_feature, {ident, _, Ident}, undefined}) ->
+    [ $(, Ident, $) ];
+serialize_media_term({media_feature, {ident, _, Ident}, Expr}) ->
+    [ $(, Ident, $:, serialize_expr(Expr), $) ].
 
 serialize_rule({rule, SelectorList, Declarations}) ->
     [
@@ -324,6 +345,7 @@ serialize_expr({exs, _, V}) -> V;
 serialize_expr({angle, _, V}) -> V;
 serialize_expr({time, _, V}) -> V;
 serialize_expr({freq, _, V}) -> V;
+serialize_expr({resolution, _, V}) -> V;
 serialize_expr({dimension, _, V}) -> V;
 serialize_expr({percentage, _, V}) -> V;
 serialize_expr({string, _, V}) -> V;
@@ -332,4 +354,3 @@ serialize_expr({operator, Op, E1, E2}) ->
     [ serialize_expr(E1), z_convert:to_list(Op), serialize_expr(E2) ];
 serialize_expr({operator, Op, E1}) ->
     [ z_convert:to_list(Op), serialize_expr(E1) ].
-

--- a/src/z_css.erl
+++ b/src/z_css.erl
@@ -262,7 +262,7 @@ serialize_media_term({ident, _, Ident}) ->
 serialize_media_term({media_feature, {ident, _, Ident}, undefined}) ->
     [ $(, Ident, $) ];
 serialize_media_term({media_feature, {ident, _, Ident}, Expr}) ->
-    [ $(, Ident, $:, serialize_expr(Expr), $) ].
+    [ $(, Ident, $:, serialize_expr(sanitize_expr(Expr)), $) ].
 
 serialize_rule({rule, SelectorList, Declarations}) ->
     [

--- a/src/z_css_lexer.xrl
+++ b/src/z_css_lexer.xrl
@@ -50,9 +50,11 @@ CSS_w           = ({CSS_s}?)
 CSS_nl          = [\n|\r|\f]
 
 A           = (a|A|\\0{0,4}(41|61)\s?)
+B           = (b|B|\\0{0,4}(42|62)\s?|\\b|\\B)
 C           = (c|C|\\0{0,4}(43|63)\s?)
 D           = (d|D|\\0{0,4}(44|64)\s?)
 E           = (e|E|\\0{0,4}(45|65)\s?)
+F           = (f|F|\\0{0,4}(46|66)\s?|\\f|\\F)
 G           = (g|G|\\0{0,4}(47|67)\s?|\\g|\\G)
 H           = (h|H|\\0{0,4}(48|68)\s?|\\h|\\H)
 I           = (i|I|\\0{0,4}(49|69)\s?|\\i|\\I)
@@ -62,10 +64,13 @@ M           = (m|M|\\0{0,4}(4d|6d)\s?|\\m|\\M)
 N           = (n|N|\\0{0,4}(4e|6e)\s?|\\n|\\N)
 O           = (o|O|\\0{0,4}(4f|6f)\s?|\\o|\\O)
 P           = (p|P|\\0{0,4}(50|70)\s?|\\p|\\P)
+Q           = (q|Q|\\0{0,4}(51|71)\s?|\\q|\\Q)
 R           = (r|R|\\0{0,4}(52|72)\s?|\\r|\\R)
 S           = (s|S|\\0{0,4}(53|73)\s?|\\s|\\S)
 T           = (t|T|\\0{0,4}(54|74)\s?|\\t|\\T)
 U           = (u|U|\\0{0,4}(55|75)\s?|\\u|\\U)
+V           = (v|V|\\0{0,4}(56|76)\s?|\\v|\\V)
+W           = (w|W|\\0{0,4}(57|77)\s?|\\w|\\W)
 X           = (x|X|\\0{0,4}(58|78)\s?|\\x|\\X)
 Z           = (z|Z|\\0{0,4}(5a|7a)\s?|\\z|\\Z)
 
@@ -91,6 +96,7 @@ Rules.
 #{CSS_name}                             : make_token(hash, TokenLine, TokenChars).
 
 @{I}{M}{P}{O}{R}{T}                     : make_token(import_sym, TokenLine, TokenChars).
+@{F}{O}{N}{T}-{F}{A}{C}{E}              : make_token(font_face_sym, TokenLine, TokenChars).
 @{P}{A}{G}{E}                           : make_token(page_sym, TokenLine, TokenChars).
 @{M}{E}{D}{I}{A}                        : make_token(media_sym, TokenLine, TokenChars).
 @{C}{H}{A}{R}{S}{E}{T}\s                : make_token(charset_sym, TokenLine, TokenChars).
@@ -99,19 +105,65 @@ Rules.
 
 {CSS_num}{E}{M}                         : make_token(ems, TokenLine, TokenChars).
 {CSS_num}{E}{X}                         : make_token(exs, TokenLine, TokenChars).
+{CSS_num}{C}{A}{P}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{C}{H}                         : make_token(length, TokenLine, TokenChars).
+{CSS_num}{I}{C}                         : make_token(length, TokenLine, TokenChars).
+{CSS_num}{L}{H}                         : make_token(length, TokenLine, TokenChars).
+{CSS_num}{R}{E}{M}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{R}{E}{X}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{R}{C}{A}{P}                   : make_token(length, TokenLine, TokenChars).
+{CSS_num}{R}{C}{H}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{R}{I}{C}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{R}{L}{H}                      : make_token(length, TokenLine, TokenChars).
 {CSS_num}{P}{X}                         : make_token(length, TokenLine, TokenChars).
 {CSS_num}{C}{M}                         : make_token(length, TokenLine, TokenChars).
 {CSS_num}{M}{M}                         : make_token(length, TokenLine, TokenChars).
+{CSS_num}{Q}                            : make_token(length, TokenLine, TokenChars).
 {CSS_num}{I}{N}                         : make_token(length, TokenLine, TokenChars).
 {CSS_num}{P}{T}                         : make_token(length, TokenLine, TokenChars).
 {CSS_num}{P}{C}                         : make_token(length, TokenLine, TokenChars).
+{CSS_num}{V}{W}                         : make_token(length, TokenLine, TokenChars).
+{CSS_num}{V}{H}                         : make_token(length, TokenLine, TokenChars).
+{CSS_num}{V}{I}                         : make_token(length, TokenLine, TokenChars).
+{CSS_num}{V}{B}                         : make_token(length, TokenLine, TokenChars).
+{CSS_num}{V}{M}{I}{N}                   : make_token(length, TokenLine, TokenChars).
+{CSS_num}{V}{M}{A}{X}                   : make_token(length, TokenLine, TokenChars).
+{CSS_num}{S}{V}{W}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{S}{V}{H}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{S}{V}{I}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{S}{V}{B}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{S}{V}{M}{I}{N}                : make_token(length, TokenLine, TokenChars).
+{CSS_num}{S}{V}{M}{A}{X}                : make_token(length, TokenLine, TokenChars).
+{CSS_num}{L}{V}{W}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{L}{V}{H}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{L}{V}{I}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{L}{V}{B}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{L}{V}{M}{I}{N}                : make_token(length, TokenLine, TokenChars).
+{CSS_num}{L}{V}{M}{A}{X}                : make_token(length, TokenLine, TokenChars).
+{CSS_num}{D}{V}{W}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{D}{V}{H}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{D}{V}{I}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{D}{V}{B}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{D}{V}{M}{I}{N}                : make_token(length, TokenLine, TokenChars).
+{CSS_num}{D}{V}{M}{A}{X}                : make_token(length, TokenLine, TokenChars).
+{CSS_num}{C}{Q}{W}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{C}{Q}{H}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{C}{Q}{I}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{C}{Q}{B}                      : make_token(length, TokenLine, TokenChars).
+{CSS_num}{C}{Q}{M}{I}{N}                : make_token(length, TokenLine, TokenChars).
+{CSS_num}{C}{Q}{M}{A}{X}                : make_token(length, TokenLine, TokenChars).
 {CSS_num}{D}{E}{G}                      : make_token(angle, TokenLine, TokenChars).
 {CSS_num}{R}{A}{D}                      : make_token(angle, TokenLine, TokenChars).
 {CSS_num}{G}{R}{A}{D}                   : make_token(angle, TokenLine, TokenChars).
+{CSS_num}{T}{U}{R}{N}                   : make_token(angle, TokenLine, TokenChars).
 {CSS_num}{M}{S}                         : make_token(time, TokenLine, TokenChars).
 {CSS_num}{S}                            : make_token(time, TokenLine, TokenChars).
 {CSS_num}{H}{Z}                         : make_token(freq, TokenLine, TokenChars).
 {CSS_num}{K}{H}{Z}                      : make_token(freq, TokenLine, TokenChars).
+{CSS_num}{D}{P}{I}                      : make_token(resolution, TokenLine, TokenChars).
+{CSS_num}{D}{P}{C}{M}                   : make_token(resolution, TokenLine, TokenChars).
+{CSS_num}{D}{P}{P}{X}                   : make_token(resolution, TokenLine, TokenChars).
+{CSS_num}{X}                            : make_token(resolution, TokenLine, TokenChars).
 {CSS_num}{CSS_ident}                    : make_token(dimension, TokenLine, TokenChars).
 {CSS_num}%                              : make_token(percentage, TokenLine, TokenChars).
 {CSS_num}                               : make_token(number, TokenLine, TokenChars).

--- a/src/z_css_parser.yrl
+++ b/src/z_css_parser.yrl
@@ -22,12 +22,18 @@ Nonterminals
     Stylesheet
     Charset
     Import
+    ImportList
     Location
     MediaList
+    MediaQuery
+    MediaTerm
     Rules
     RuleSetList
     RuleSet
     Media
+    FontFace
+    FontFaceBody
+    FontFaceToken
     Page
     DeclarationList
     Declaration
@@ -49,14 +55,15 @@ Nonterminals
 
 Terminals
 
-    % badcomment
+    badcomment
     includes
     dashmatch
     string
-    % bad_string
+    bad_string
     ident
     hash
     import_sym
+    font_face_sym
     page_sym
     media_sym
     charset_sym
@@ -67,17 +74,19 @@ Terminals
     angle
     time
     freq
+    resolution
     dimension
     percentage
     number
     uri
-    % bad_uri
+    bad_uri
     function
     ';'
     '{'
     '}'
     '['
     ']'
+    '('
     ')'
     ','
     '.'
@@ -96,31 +105,87 @@ Rootsymbol
 %% Expected shift/reduce conflicts
 Expect 0.
 
-Stylesheet -> Charset Import Rules      : {stylesheet, '$1', '$2', '$3'}.
+Stylesheet -> Charset ImportList Rules      : {stylesheet, '$1', '$2', '$3'}.
 
 Charset -> '$empty'                     : no_charset.
 Charset -> charset_sym string ';'       : {charset, '$2'}.
 
-Import -> '$empty'                           : no_import.
 Import -> import_sym Location MediaList ';'  : {import, '$2', '$3'}.
+
+ImportList -> '$empty'                       : no_import.
+ImportList -> Import ImportList              : no_import.
 
 Location -> string                        : '$1'.
 Location -> uri                           : '$1'.
 
 Media -> media_sym MediaList '{' RuleSetList '}' : {media, '$2', '$4'}.
 
-MediaList -> ident                       : ['$1'].
-MediaList -> ident ',' MediaList         : ['$1'] ++ '$3'.
+MediaList -> MediaQuery                       : ['$1'].
+MediaList -> MediaQuery ',' MediaList         : ['$1' | '$3'].
+
+MediaQuery -> MediaTerm                       : ['$1'].
+MediaQuery -> MediaQuery MediaTerm            : '$1' ++ ['$2'].
+
+MediaTerm -> ident                            : '$1'.
+MediaTerm -> '(' ident ')'                    : {media_feature, '$2', undefined}.
+MediaTerm -> '(' ident ':' Expr ')'           : {media_feature, '$2', '$4'}.
 
 Rules -> '$empty'                         : [].
 Rules -> RuleSet Rules                    : ['$1' | '$2'].
 Rules -> Media Rules                      : ['$1' | '$2'].
+Rules -> FontFace Rules                   : '$2'.
 Rules -> Page Rules                       : ['$1' | '$2'].
 
 RuleSetList -> '$empty'                   : [].
 RuleSetList -> RuleSet RuleSetList        : ['$1' | '$2'].
+RuleSetList -> FontFace RuleSetList       : '$2'.
 
 RuleSet -> SelectorList '{' DeclarationList '}' : {rule, '$1', '$3'}.
+
+FontFace -> font_face_sym '{' FontFaceBody '}' : no_font_face.
+
+FontFaceBody -> '$empty'                   : [].
+FontFaceBody -> FontFaceToken FontFaceBody : ['$1' | '$2'].
+
+FontFaceToken -> badcomment                : '$1'.
+FontFaceToken -> includes                  : '$1'.
+FontFaceToken -> dashmatch                 : '$1'.
+FontFaceToken -> string                    : '$1'.
+FontFaceToken -> bad_string                : '$1'.
+FontFaceToken -> ident                     : '$1'.
+FontFaceToken -> hash                      : '$1'.
+FontFaceToken -> import_sym                : '$1'.
+FontFaceToken -> page_sym                  : '$1'.
+FontFaceToken -> media_sym                 : '$1'.
+FontFaceToken -> charset_sym               : '$1'.
+FontFaceToken -> important_sym             : '$1'.
+FontFaceToken -> ems                       : '$1'.
+FontFaceToken -> exs                       : '$1'.
+FontFaceToken -> length                    : '$1'.
+FontFaceToken -> angle                     : '$1'.
+FontFaceToken -> time                      : '$1'.
+FontFaceToken -> freq                      : '$1'.
+FontFaceToken -> resolution                : '$1'.
+FontFaceToken -> dimension                 : '$1'.
+FontFaceToken -> percentage                : '$1'.
+FontFaceToken -> number                    : '$1'.
+FontFaceToken -> uri                       : '$1'.
+FontFaceToken -> bad_uri                   : '$1'.
+FontFaceToken -> function                  : '$1'.
+FontFaceToken -> ';'                       : '$1'.
+FontFaceToken -> '['                       : '$1'.
+FontFaceToken -> ']'                       : '$1'.
+FontFaceToken -> '('                       : '$1'.
+FontFaceToken -> ')'                       : '$1'.
+FontFaceToken -> ','                       : '$1'.
+FontFaceToken -> '.'                       : '$1'.
+FontFaceToken -> ':'                       : '$1'.
+FontFaceToken -> '*'                       : '$1'.
+FontFaceToken -> '/'                       : '$1'.
+FontFaceToken -> '='                       : '$1'.
+FontFaceToken -> '>'                       : '$1'.
+FontFaceToken -> '-'                       : '$1'.
+FontFaceToken -> '+'                       : '$1'.
 
 SelectorList -> Selector                    : ['$1'].
 SelectorList -> SelectorList ',' Selector   : '$1' ++ ['$3'].
@@ -148,6 +213,7 @@ Term -> exs                                 : '$1'.
 Term -> angle                               : '$1'.
 Term -> time                                : '$1'.
 Term -> freq                                : '$1'.
+Term -> resolution                          : '$1'.
 Term -> dimension                           : '$1'.
 Term -> string                              : '$1'.
 Term -> ident                               : '$1'.
@@ -190,5 +256,3 @@ Page -> page_sym PseudoPage '{' DeclarationList '}' : {page, '$2', '$4'}.
 
 PseudoPage -> '$empty'                  : undefined.
 PseudoPage -> ':' ident                 : '$1'.
-
-

--- a/test/z_css_test.erl
+++ b/test/z_css_test.erl
@@ -21,7 +21,21 @@ sanitize_media_test() ->
         z_css:sanitize(<<"@media screen {p{background:url(http://example.com)}}">>)),
     ?assertEqual(
         {ok, <<"@media screen,print,foobar {\n}\n">>},
-        z_css:sanitize(<<"@media screen,print,foobar { }">>)).
+        z_css:sanitize(<<"@media screen,print,foobar { }">>)),
+    ?assertEqual(
+        {ok, <<"@media only screen and (max-width:600px) {\np {\nbackground-image:url();\n}\n}\n">>},
+        z_css:sanitize(<<"@media only screen and (max-width: 600px) { p { background-image: url(https://example.com/x.png) } }">>)).
+
+sanitize_external_references_test() ->
+    ?assertEqual(
+        {ok, <<"p {\ncolor:red;\n}\n">>},
+        z_css:sanitize(<<"@import url(https://example.com/a.css) screen; @import \"https://example.com/b.css\" print; p { color: red }">>)),
+    ?assertEqual(
+        {ok, <<"p {\nfont-family:Example;\n}\n">>},
+        z_css:sanitize(<<"@font-face { font-family: Example; src: url(https://example.com/font.woff2) format(\"woff2\"); } p { font-family: Example }">>)),
+    ?assertEqual(
+        {ok, <<"@media only screen and (max-width:600px) {\np {\ncolor:red;\n}\n}\n">>},
+        z_css:sanitize(<<"@media only screen and (max-width: 600px) { @font-face { src: url(https://example.com/font.woff2); } p { color: red } }">>)).
 
 sanitize_content_test() ->
     ?assertEqual(
@@ -31,5 +45,21 @@ sanitize_content_test() ->
 sanitize_unit_test() ->
     ?assertEqual(
         {ok,<<"a {\nc:100%;\nd:1em;\ne:2px;\nf:a,b,c;\n}\n">>},
-        z_css:sanitize(<<"a {\nc:100%; d:1em; e:2px; f:a,b,c;\n}\n">>)).
-
+        z_css:sanitize(<<"a {\nc:100%; d:1em; e:2px; f:a,b,c;\n}\n">>)),
+    Units = [
+        <<"cap">>, <<"ch">>, <<"cm">>, <<"cqb">>, <<"cqh">>, <<"cqi">>, <<"cqmax">>, <<"cqmin">>, <<"cqw">>,
+        <<"deg">>, <<"dpcm">>, <<"dpi">>, <<"dppx">>, <<"dvb">>, <<"dvh">>, <<"dvi">>, <<"dvmax">>,
+        <<"dvmin">>, <<"dvw">>, <<"em">>, <<"ex">>, <<"fr">>, <<"grad">>, <<"Hz">>, <<"ic">>, <<"in">>,
+        <<"kHz">>, <<"lh">>, <<"lvb">>, <<"lvh">>, <<"lvi">>, <<"lvmax">>, <<"lvmin">>, <<"lvw">>, <<"mm">>,
+        <<"ms">>, <<"pc">>, <<"pt">>, <<"px">>, <<"Q">>, <<"rad">>, <<"rcap">>, <<"rch">>, <<"rem">>,
+        <<"rex">>, <<"ric">>, <<"rlh">>, <<"s">>, <<"svb">>, <<"svh">>, <<"svi">>, <<"svmax">>,
+        <<"svmin">>, <<"svw">>, <<"turn">>, <<"vb">>, <<"vh">>, <<"vi">>, <<"vmax">>, <<"vmin">>,
+        <<"vw">>, <<"x">>
+    ],
+    Css = iolist_to_binary([
+        <<"a {\n">>,
+        [ [ <<"u">>, integer_to_binary(N), <<":1">>, Unit, <<";\n">> ]
+            || {N, Unit} <- lists:zip(lists:seq(1, length(Units)), Units) ],
+        <<"}\n">>
+    ]),
+    ?assertMatch({ok, _}, z_css:sanitize(Css)).


### PR DESCRIPTION
This pull request significantly improves CSS parsing and sanitization by expanding support for modern CSS features, especially in media queries, units, and at-rules. The lexer, parser, and sanitizer now recognize a much broader range of CSS units and at-rules, and the media query grammar has been refactored for better standards compliance. Comprehensive tests have been added to ensure correctness.

**Expanded CSS Feature Support**

* The lexer and parser now recognize a much wider set of CSS units (e.g., `cap`, `ch`, `ic`, `lh`, `rlh`, `svw`, `lvh`, `dvb`, `q`, `turn`, `dppx`, etc.), as well as new types like `resolution`, and new at-rules such as `@font-face`. (`src/z_css_lexer.xrl`: [[1]](diffhunk://#diff-6972ff0319136f0fd2a0bbb2ca4fc78dc44d78aa8a6260f032e4703fdf6c448bR108-R166) [[2]](diffhunk://#diff-6972ff0319136f0fd2a0bbb2ca4fc78dc44d78aa8a6260f032e4703fdf6c448bR53-R57) [[3]](diffhunk://#diff-6972ff0319136f0fd2a0bbb2ca4fc78dc44d78aa8a6260f032e4703fdf6c448bR67-R73); `src/z_css_parser.yrl`: [[4]](diffhunk://#diff-02ac129a820c1ba5e94b8520c9152192fa662ef40604ebfc0bb8d661a8ac4c94R25-R36) [[5]](diffhunk://#diff-02ac129a820c1ba5e94b8520c9152192fa662ef40604ebfc0bb8d661a8ac4c94L52-R66) [[6]](diffhunk://#diff-02ac129a820c1ba5e94b8520c9152192fa662ef40604ebfc0bb8d661a8ac4c94R77-R89) [[7]](diffhunk://#diff-02ac129a820c1ba5e94b8520c9152192fa662ef40604ebfc0bb8d661a8ac4c94R216)
* The sanitizer and serializer functions have been updated to handle these new units and at-rules, including new cases for `resolution` and `font-face`. (`src/z_css.erl`: [[1]](diffhunk://#diff-630b0d4d8aa8cf3d4f99f53f8efcd2fc36a92481c58d8782b34e6848bd235087R62) [[2]](diffhunk://#diff-630b0d4d8aa8cf3d4f99f53f8efcd2fc36a92481c58d8782b34e6848bd235087R193) [[3]](diffhunk://#diff-630b0d4d8aa8cf3d4f99f53f8efcd2fc36a92481c58d8782b34e6848bd235087R348) [[4]](diffhunk://#diff-630b0d4d8aa8cf3d4f99f53f8efcd2fc36a92481c58d8782b34e6848bd235087R51)

**Media Query Grammar Refactor**

* The parser's media query grammar has been refactored to support complex queries, including nested media features (e.g., `@media only screen and (max-width: 600px)`). Serialization logic has been updated to match. (`src/z_css_parser.yrl`: [[1]](diffhunk://#diff-02ac129a820c1ba5e94b8520c9152192fa662ef40604ebfc0bb8d661a8ac4c94L99-R189) [[2]](diffhunk://#diff-02ac129a820c1ba5e94b8520c9152192fa662ef40604ebfc0bb8d661a8ac4c94R216); `src/z_css.erl`: [[3]](diffhunk://#diff-630b0d4d8aa8cf3d4f99f53f8efcd2fc36a92481c58d8782b34e6848bd235087L75-R79) [[4]](diffhunk://#diff-630b0d4d8aa8cf3d4f99f53f8efcd2fc36a92481c58d8782b34e6848bd235087L244-R265)

**New and Improved At-rule Handling**

* Added support for parsing and sanitizing `@font-face` rules and improved handling of `@import` rules, including the ability to filter out external references. (`src/z_css_parser.yrl`: [[1]](diffhunk://#diff-02ac129a820c1ba5e94b8520c9152192fa662ef40604ebfc0bb8d661a8ac4c94R25-R36) [[2]](diffhunk://#diff-02ac129a820c1ba5e94b8520c9152192fa662ef40604ebfc0bb8d661a8ac4c94L99-R189); `src/z_css.erl`: [[3]](diffhunk://#diff-630b0d4d8aa8cf3d4f99f53f8efcd2fc36a92481c58d8782b34e6848bd235087R51)
* The lexer now recognizes `@font-face` as a distinct symbol. (`src/z_css_lexer.xrl`: [src/z_css_lexer.xrlR99](diffhunk://#diff-6972ff0319136f0fd2a0bbb2ca4fc78dc44d78aa8a6260f032e4703fdf6c448bR99))

**Testing Enhancements**

* New and extended test cases cover the expanded set of CSS units, complex media queries, and at-rule sanitization, ensuring the new grammar and sanitizer logic work as intended. (`test/z_css_test.erl`: [[1]](diffhunk://#diff-2b17218f79349664d5a121abbb7d63863710e29232b27979ee4c253d412c795aL24-R38) [[2]](diffhunk://#diff-2b17218f79349664d5a121abbb7d63863710e29232b27979ee4c253d412c795aL34-R65)

These changes make the CSS parser and sanitizer much more robust and compatible with modern CSS syntax and features.