### PR TITLE
UBF: add map support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Temporary file routines. Make tempfiles, including watch dog process to clean up
 
 UBF-A encoding and decoding routines. Safe for atoms and maximum memory size.
 
+Maps are encoded as a UBF-A list of `{Key, Value}` tuples followed by the type
+tag `` `map` ``. For example, `#{a => 1, b => 2}` is encoded as
+`#{'b',2}&{'a',1}&`map`$`. The pair order is canonicalized by Erlang term order
+before encoding. Decoding accepts the pair list and converts it with
+`maps:from_list/1`; duplicate keys follow the same last-value-wins semantics.
+
 
 ### z_url
 
@@ -138,4 +144,3 @@ To run the test set:
     make test
 
 All tests should pass.
-

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ UBF-A encoding and decoding routines. Safe for atoms and maximum memory size.
 
 Maps are encoded as a UBF-A list of `{Key, Value}` tuples followed by the type
 tag `` `map` ``. For example, `#{a => 1, b => 2}` is encoded as
-`#{'b',2}&{'a',1}&`map`$`. The pair order is canonicalized by Erlang term order
+``#{'b',2}&{'a',1}&`map`$``. The pair order is canonicalized by Erlang term order
 before encoding. Decoding accepts the pair list and converts it with
 `maps:from_list/1`; duplicate keys follow the same last-value-wins semantics.
 

--- a/src/z_css.erl
+++ b/src/z_css.erl
@@ -1,5 +1,5 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2014-2025 Marc Worrell
+%% @copyright 2014-2026 Marc Worrell
 %% @doc Utility functions for CSS processing. This sanitizer is used by the
 %% HTML sanitizer for processing style attributes. It can also be called independently
 %% to sanitize CSS.
@@ -13,7 +13,7 @@
 %% The grammar is included in z_css_parser.yrl and the lexer is in z_css_lexer.xrl.
 %% @end
 
-%% Copyright 2014-2025 Marc Worrell
+%% Copyright 2014-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/z_css_lexer.xrl
+++ b/src/z_css_lexer.xrl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2014-2025 Marc Worrell
+%% @copyright 2014-2026 Marc Worrell
 %% @doc Grammar for strict CSS parser. Based on http://www.w3.org/TR/CSS21/grammar.html
 %% @end
 
-%% Copyright 2014-2025 Marc Worrell
+%% Copyright 2014-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/z_css_parser.yrl
+++ b/src/z_css_parser.yrl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2014-2025 Marc Worrell
+%% @copyright 2014-2026 Marc Worrell
 %% @doc Grammar for strict CSS parser. Based on http://www.w3.org/TR/CSS21/grammar.html
 %% @end
 
-%% Copyright 2014-2025 Marc Worrell
+%% Copyright 2014-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/z_ubf.erl
+++ b/src/z_ubf.erl
@@ -126,7 +126,7 @@ get_stuff(<<$`,T/binary>>, $`, L, [[H|Tail]|Stack] = TS, Dict, MaxSize)  ->
         <<"plist">> ->
             decode1(T, TS, Dict, MaxSize);
         <<"map">> ->
-            Map = maps:from_list(H),
+            Map = maps:from_list(lists:reverse(H)),
             decode1(T, [[Map|Tail]|Stack], Dict, MaxSize - erts_debug:flat_size(Map));
         <<"f">> ->
             F = erlang:binary_to_float(H),

--- a/src/z_ubf.erl
+++ b/src/z_ubf.erl
@@ -127,7 +127,7 @@ get_stuff(<<$`,T/binary>>, $`, L, [[H|Tail]|Stack] = TS, Dict, MaxSize)  ->
             decode1(T, TS, Dict, MaxSize);
         <<"map">> ->
             Map = maps:from_list(lists:reverse(H)),
-            decode1(T, [[Map|Tail]|Stack], Dict, MaxSize - erts_debug:flat_size(Map));
+            decode1(T, [[Map|Tail]|Stack], Dict, MaxSize - map_container_size(Map));
         <<"f">> ->
             F = erlang:binary_to_float(H),
             decode1(T, [[F|Tail]|Stack], Dict, MaxSize - erts_debug:flat_size(F));
@@ -158,6 +158,16 @@ expect_tilde(<<>>, Stack, Dict, MaxSize) ->
     {more, fun(I) -> expect_tilde(I, Stack, Dict, MaxSize) end};
 expect_tilde(<<H,_/binary>>, _Stack, _Dict, _MaxSize) ->
     exit({expect_tilde, H}).
+
+map_container_size(Map) ->
+    %% The map keys and values were already charged while decoding the UBF-A
+    %% pair list. Only charge the additional map container, not the subterms.
+    max(0, maps:fold(
+        fun(K, V, Size) ->
+            Size - erts_debug:size(K) - erts_debug:size(V)
+        end,
+        erts_debug:size(Map),
+        Map)).
 
 push(X, [Top|Rest]) ->
     [[X|Top]|Rest];

--- a/src/z_ubf.erl
+++ b/src/z_ubf.erl
@@ -40,6 +40,7 @@
 %% Int            -> Int
 %% [ ]            -> List
 %% {...}          -> Tuple
+%% #{K,V}&...&`map` -> Map
 
 %% decode_init() -> Cont
 %% decode(Str, Cont) -> {more, Cont'} | {done, Term, Str}
@@ -125,8 +126,8 @@ get_stuff(<<$`,T/binary>>, $`, L, [[H|Tail]|Stack] = TS, Dict, MaxSize)  ->
         <<"plist">> ->
             decode1(T, TS, Dict, MaxSize);
         <<"map">> ->
-            % @todo: add conditional compilation for list to map
-            decode1(T, TS, Dict, MaxSize);
+            Map = maps:from_list(H),
+            decode1(T, [[Map|Tail]|Stack], Dict, MaxSize - erts_debug:flat_size(Map));
         <<"f">> ->
             F = erlang:binary_to_float(H),
             decode1(T, [[F|Tail]|Stack], Dict, MaxSize - erts_debug:flat_size(F));
@@ -257,6 +258,13 @@ rank({X, _}) ->
 
 analyse({'#S', Str}, Dict) ->
     analyse(Str, Dict);
+analyse(T, Dict) when is_map(T) ->
+    lists:foldl(
+        fun({K, V}, Acc) ->
+            analyse(V, analyse(K, Acc))
+        end,
+        Dict,
+        maps:to_list(T));
 analyse(T, Dict) when is_tuple(T) ->
     lists:foldl(fun analyse/2, Dict, tuple_to_list(T)); 
 analyse(X, Dict) ->
@@ -292,6 +300,9 @@ do_encode({{Y,M,D},{H,I,S}} = DT, Dict, Options)
         undefined -> do_encode(undefined, Dict, Options);
         Timestamp -> [integer_to_binary(Timestamp),"`dt`"]
     end;
+do_encode(Map, Dict, Options) when is_map(Map) ->
+    Enc = encode_list(lists:sort(maps:to_list(Map)), Dict, [], Options),
+    [$#, Enc, "`map`"];
 do_encode([_|_] = List, Dict, Options) ->
     Enc = encode_list(List, Dict, [], Options),
     case list_type(List, Options) of
@@ -345,6 +356,11 @@ add_string([H|_], _Quote) -> exit({string_character,H});
 add_string([], _)            -> [].
 
 deabstract({'#S',S}) -> S;
+deabstract(T) when is_map(T) ->
+    maps:from_list([
+        {deabstract(K), deabstract(V)}
+        || {K, V} <- maps:to_list(T)
+    ]);
 deabstract(T) when is_tuple(T) ->
     list_to_tuple(lists:map(fun deabstract/1, tuple_to_list(T)));
 deabstract([H|T]) -> [deabstract(H)|deabstract(T)];
@@ -360,4 +376,3 @@ datetime_to_timestamp({{9999,_,_},{_,_,_}}) ->
     undefined;
 datetime_to_timestamp({{_,_,_},{_,_,_}} = DT) ->
     calendar:datetime_to_gregorian_seconds(DT) - ?SECS_1970.
-

--- a/src/z_ubf.erl
+++ b/src/z_ubf.erl
@@ -3,7 +3,7 @@
 %%% Adapted for binary strings and data by Marc Worrell
 
 %%% Copyright 2002-2003 Joe Armstrong.
-%%% Copyright 2013 Marc Worrell.
+%%% Copyright 2013-2026 Marc Worrell.
 %%%
 %%% All rights reserved.
 %%%

--- a/test/z_ubf_test.erl
+++ b/test/z_ubf_test.erl
@@ -46,6 +46,10 @@ map_test() ->
     ?assertEqual(M, M1),
     ?assertEqual(<<"#{'b',2}&{'a',1}&`map`$">>, Enc).
 
+map_duplicate_keys_decode_test() ->
+    {ok, M, _} = z_ubf:decode(<<"#{'a',1}&{'a',2}&`map`$">>),
+    ?assertEqual(#{a => 2}, M).
+
 empty_map_test() ->
     M = #{},
     {ok, Enc} = z_ubf:encode(M),

--- a/test/z_ubf_test.erl
+++ b/test/z_ubf_test.erl
@@ -39,6 +39,46 @@ proplist_test() ->
     ?assertEqual(L, L1),
     ?assertEqual(Enc, <<"#{'b',2}&{'a',1}&`plist`$">>).
 
+map_test() ->
+    M = #{a => 1, b => 2},
+    {ok, Enc} = z_ubf:encode(M),
+    {ok, M1, _} = z_ubf:decode(Enc),
+    ?assertEqual(M, M1),
+    ?assertEqual(<<"#{'b',2}&{'a',1}&`map`$">>, Enc).
+
+empty_map_test() ->
+    M = #{},
+    {ok, Enc} = z_ubf:encode(M),
+    {ok, M1, _} = z_ubf:decode(Enc),
+    ?assertEqual(M, M1),
+    ?assertEqual(<<"#`map`$">>, Enc).
+
+nested_map_test() ->
+    M = #{
+        a => #{b => 2},
+        <<"list">> => [#{c => 3}]
+    },
+    {ok, Enc} = z_ubf:encode(M),
+    {ok, M1, _} = z_ubf:decode(Enc),
+    ?assertEqual(M, M1).
+
+map_deabstract_test() ->
+    ?assertEqual(
+        #{
+            a => #{b => 2},
+            "key" => "value"
+        },
+        z_ubf:deabstract(#{
+            a => #{b => 2},
+            {'#S', "key"} => {'#S', "value"}
+        })).
+
+map_stream_decode_test() ->
+    {more, Cont} = z_ubf:decode(<<"#{'b',2}&">>),
+    {done, M, Rest} = z_ubf:decode(<<"{'a',1}&`map`$rest">>, {more, Cont}),
+    ?assertEqual(#{a => 1, b => 2}, M),
+    ?assertEqual(<<"rest">>, Rest).
+
 recordlist_test() ->
     L = [{a,1},{b,2},{a,3},{b,4}],
     {ok, Enc} = z_ubf:encode(L, [{record_names, [a, b]}]),
@@ -51,5 +91,3 @@ recordlist_test() ->
 %    %% was never called, but points to a bug.
 %    C = z_ubf:decode("{'abc"),
 %    z_ubf:decode("d'}$", C).
-
-

--- a/test/z_ubf_test.erl
+++ b/test/z_ubf_test.erl
@@ -50,6 +50,11 @@ map_duplicate_keys_decode_test() ->
     {ok, M, _} = z_ubf:decode(<<"#{'a',1}&{'a',2}&`map`$">>),
     ?assertEqual(#{a => 2}, M).
 
+map_size_limit_test() ->
+    Enc = <<"#{1~a~,1~b~}&`map`$">>,
+    ?assertEqual({ok, #{<<"a">> => <<"b">>}, <<>>}, z_ubf:decode(Enc, 8)),
+    ?assertEqual({error, size}, z_ubf:decode(Enc, 7)).
+
 empty_map_test() ->
     M = #{},
     {ok, Enc} = z_ubf:encode(M),


### PR DESCRIPTION
Fixes #17 

This pull request adds support for Erlang maps in the UBF-A encoding/decoding routines, updates documentation, and introduces comprehensive tests for map handling. The main changes are in the `z_ubf.erl` module to support encoding, decoding, and de-abstraction of maps, and in the test suite to ensure correct behavior.

**UBF-A Map Support:**

* Added encoding and decoding logic for Erlang maps in `z_ubf.erl`, including canonicalization of key order and handling of the `map` type tag. [[1]](diffhunk://#diff-e44b9e73cd93e96f768e1bb1a6ed8d7fcd5ea5a80d20a694ddbafdbb244d74dfR43) [[2]](diffhunk://#diff-e44b9e73cd93e96f768e1bb1a6ed8d7fcd5ea5a80d20a694ddbafdbb244d74dfL128-R130) [[3]](diffhunk://#diff-e44b9e73cd93e96f768e1bb1a6ed8d7fcd5ea5a80d20a694ddbafdbb244d74dfR303-R305)
* Updated the `deabstract/1` function to support map structures, recursively deabstracting keys and values.
* Enhanced the `analyse/2` function to traverse and analyze maps during decoding.

**Documentation:**

* Updated `README.md` to document the new map encoding format and semantics, including canonical order and last-value-wins for duplicate keys.

**Testing:**

* Added comprehensive tests for map encoding, decoding, nested maps, empty maps, deabstraction, and streaming decode scenarios in `z_ubf_test.erl`.

Other:

* Minor cleanup in `README.md` and `z_ubf.erl` for consistency and formatting. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L141) [[2]](diffhunk://#diff-e44b9e73cd93e96f768e1bb1a6ed8d7fcd5ea5a80d20a694ddbafdbb244d74dfL363) [[3]](diffhunk://#diff-b5fb8bd7037e45419d8c1a19f7b408be986f0d47335112de7ccaca80fcc6a3f3L54-L55)