### PR TITLE
z_convert: add long to ip6

### DIFF
--- a/src/z_convert.erl
+++ b/src/z_convert.erl
@@ -397,8 +397,7 @@ ip_to_list({_K1,_K2,_K3,_K4,_K5,_K6,_K7,_K8} = IPv6) ->
 
 
 %% Taken from egeoip (http://code.google.com/p/egeoip/source/browse/trunk/egeoip/src/egeoip.erl?r=19)
-%% @doc Convert an IPv4 or IPv6 tuple to the big endian integer
-%%      representation.
+%% @doc Convert an IPv4 or IPv6 tuple to the big endian integer representation.
 -spec ip_to_long(inet:ip_address()) -> {ok, integer()} | {error, badmatch}.
 ip_to_long({B3, B2, B1, B0}) ->
     {ok, (B3 bsl 24) bor (B2 bsl 16) bor (B1 bsl 8) bor B0};
@@ -412,7 +411,10 @@ ip_to_long(_) ->
 -define(UINT32_MAX, 16#FFFFFFFF).
 -define(UINT128_MAX, 16#FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF).
 
-%% @doc Convert long int to IPv4 or IPv6 address tuple.
+%% @doc Convert long int to IPv4 or IPv6 address tuple. Note that IP addresses fitting in the
+%% 32 bit IPv4 address space are always converted to IPv4 tuples. Integers outside the IPv4 address space
+%% are converted to IPv6 tuples. Error badarg is returned for negative integers and integers larger
+%% than the maximum 128 bit integer.
 -spec long_to_ip(integer()) -> {ok, inet:ip_address()} | {error, badmatch}.
 long_to_ip(L) when is_integer(L), L >= 0, L =< ?UINT32_MAX ->
     {ok, {(L band (255 bsl 24)) bsr 24,

--- a/src/z_convert.erl
+++ b/src/z_convert.erl
@@ -409,12 +409,29 @@ ip_to_long(_) ->
     {error, badmatch}.
 
 
-%% @doc Convert long int to IP address tuple. FIXME: ipv6
-long_to_ip(L) ->
+-define(UINT32_MAX, 16#FFFFFFFF).
+-define(UINT128_MAX, 16#FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF).
+
+%% @doc Convert long int to IPv4 or IPv6 address tuple.
+-spec long_to_ip(integer()) -> {ok, inet:ip_address()} | {error, badmatch}.
+long_to_ip(L) when is_integer(L), L >= 0, L =< ?UINT32_MAX ->
     {ok, {(L band (255 bsl 24)) bsr 24,
           (L band (255 bsl 16)) bsr 16,
           (L band (255 bsl 8)) bsr 8,
-          L band 255}}.
+          L band 255}};
+long_to_ip(L) when is_integer(L), L >= 0, L =< ?UINT128_MAX ->
+    {ok, {
+        (L bsr 112) band 16#FFFF,
+        (L bsr 96) band 16#FFFF,
+        (L bsr 80) band 16#FFFF,
+        (L bsr 64) band 16#FFFF,
+        (L bsr 48) band 16#FFFF,
+        (L bsr 32) band 16#FFFF,
+        (L bsr 16) band 16#FFFF,
+        L band 16#FFFF
+    }};
+long_to_ip(_) ->
+    {error, badmatch}.
 
 
 %% @doc Convert json from facebook favour to an easy to use format for zotonic templates.

--- a/test/z_convert_test.erl
+++ b/test/z_convert_test.erl
@@ -62,6 +62,22 @@ convert_bool_strict_test() ->
     ?assertEqual(false, z_convert:to_bool_strict(undefined)),
     ok.
 
+ip_long_test() ->
+    IPv4 = {127, 0, 0, 1},
+    {ok, IPv4Long} = z_convert:ip_to_long(IPv4),
+    ?assertEqual(16#7F000001, IPv4Long),
+    ?assertEqual({ok, IPv4}, z_convert:long_to_ip(IPv4Long)),
+
+    IPv6 = {16#2001, 16#0DB8, 0, 0, 0, 16#FF00, 16#0042, 16#8329},
+    {ok, IPv6Long} = z_convert:ip_to_long(IPv6),
+    ?assertEqual({ok, IPv6}, z_convert:long_to_ip(IPv6Long)),
+
+    ?assertEqual({ok, {255, 255, 255, 255}}, z_convert:long_to_ip(16#FFFFFFFF)),
+    ?assertEqual({ok, {0, 0, 0, 0, 0, 1, 0, 0}}, z_convert:long_to_ip(16#100000000)),
+    ?assertEqual({error, badmatch}, z_convert:long_to_ip(-1)),
+    ?assertEqual({error, badmatch}, z_convert:long_to_ip(1 bsl 128)),
+    ok.
+
 datetime_to_iso_test() ->
     ?assertEqual(<<"2010-09-02T10:11:56Z">>, z_convert:to_isotime({{2010,9,2},{10,11,56}})),
     ?assertEqual(<<"2010-09-02T01:01:01Z">>, z_convert:to_isotime({{2010,9,2},{1,1,1}})),


### PR DESCRIPTION
This pull request extends the functionality of the `long_to_ip/1` function in `z_convert.erl` to support both IPv4 and IPv6 addresses, and adds comprehensive tests to ensure correct behavior for various cases. The changes improve the robustness and coverage of IP address conversions.

Enhancements to IP address conversion:

* Updated `long_to_ip/1` in `src/z_convert.erl` to convert both 32-bit (IPv4) and 128-bit (IPv6) integers to their respective IP address tuple representations, and added error handling for invalid input ranges.

Testing improvements:

* Added `ip_long_test/0` in `test/z_convert_test.erl` to test round-trip conversions for both IPv4 and IPv6, as well as edge cases and error handling for `long_to_ip/1`.