### PR TITLE
Fix an issue where the generated css lexer was too large

### DIFF
--- a/src/z_css.erl
+++ b/src/z_css.erl
@@ -52,6 +52,7 @@
             | page_sym
             | media_sym
             | charset_sym
+            | bad_at_rule
             | important_sym
             | ems
             | exs
@@ -125,7 +126,7 @@ sanitize(Css) when is_binary(Css) ->
         {ok, {stylesheet, Charset, Import, Rules}} ->
             Charset1 = sanitize_charset(Charset),
             Import1 = sanitize_import(Import),
-            Rules1 = [ sanitize_rule(R) || R <- Rules ],
+            Rules1 = sanitize_rules(Rules),
             {ok, unicode:characters_to_binary([
                 serialize_charset(Charset1),
                 serialize_import(Import1),
@@ -157,10 +158,18 @@ sanitize_charset(_Charset) -> no_charset.
 
 sanitize_import(_Import) -> no_import.
 
+sanitize_rules(Rules) ->
+    lists:filtermap(fun sanitize_rule_1/1, Rules).
+
+sanitize_rule_1(bad_at_rule) ->
+    false;
+sanitize_rule_1(Rule) ->
+    {true, sanitize_rule(Rule)}.
+
 sanitize_rule({rule, Selector, Declarations}) ->
     {rule, Selector, [ sanitize_declaration(D) || D <- Declarations ]};
 sanitize_rule({media, MediaList, Rules}) ->
-    {media, MediaList, [ sanitize_rule(R) || R <- Rules ]};
+    {media, MediaList, sanitize_rules(Rules)};
 sanitize_rule({page, PseudoPage, Declarations}) ->
     {page, PseudoPage, [ sanitize_declaration(D) || D <- Declarations ]}.
 

--- a/src/z_css_lexer.xrl
+++ b/src/z_css_lexer.xrl
@@ -47,7 +47,7 @@ CSS_baduri      = ({CSS_baduri1}|{CSS_baduri2}|{CSS_baduri3})
 CSS_url         = ([!#$%&*-~]|{CSS_nonascii}|{CSS_escape})*
 CSS_s           = ([\s\r\n\f\t]+)
 CSS_w           = ({CSS_s}?)
-CSS_nl          = [\n|\r|\f]
+CSS_nl          = [\n\r\f]
 
 A           = (a|A|\\0{0,4}(41|61)\s?)
 B           = (b|B|\\0{0,4}(42|62)\s?|\\b|\\B)
@@ -103,68 +103,7 @@ Rules.
 
 !({w}|{CSS_comment})*{I}{M}{P}{O}{R}{T}{A}{N}{T}  : make_token(important_sym, TokenLine, TokenChars).
 
-{CSS_num}{E}{M}                         : make_token(ems, TokenLine, TokenChars).
-{CSS_num}{E}{X}                         : make_token(exs, TokenLine, TokenChars).
-{CSS_num}{C}{A}{P}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{C}{H}                         : make_token(length, TokenLine, TokenChars).
-{CSS_num}{I}{C}                         : make_token(length, TokenLine, TokenChars).
-{CSS_num}{L}{H}                         : make_token(length, TokenLine, TokenChars).
-{CSS_num}{R}{E}{M}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{R}{E}{X}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{R}{C}{A}{P}                   : make_token(length, TokenLine, TokenChars).
-{CSS_num}{R}{C}{H}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{R}{I}{C}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{R}{L}{H}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{P}{X}                         : make_token(length, TokenLine, TokenChars).
-{CSS_num}{C}{M}                         : make_token(length, TokenLine, TokenChars).
-{CSS_num}{M}{M}                         : make_token(length, TokenLine, TokenChars).
-{CSS_num}{Q}                            : make_token(length, TokenLine, TokenChars).
-{CSS_num}{I}{N}                         : make_token(length, TokenLine, TokenChars).
-{CSS_num}{P}{T}                         : make_token(length, TokenLine, TokenChars).
-{CSS_num}{P}{C}                         : make_token(length, TokenLine, TokenChars).
-{CSS_num}{V}{W}                         : make_token(length, TokenLine, TokenChars).
-{CSS_num}{V}{H}                         : make_token(length, TokenLine, TokenChars).
-{CSS_num}{V}{I}                         : make_token(length, TokenLine, TokenChars).
-{CSS_num}{V}{B}                         : make_token(length, TokenLine, TokenChars).
-{CSS_num}{V}{M}{I}{N}                   : make_token(length, TokenLine, TokenChars).
-{CSS_num}{V}{M}{A}{X}                   : make_token(length, TokenLine, TokenChars).
-{CSS_num}{S}{V}{W}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{S}{V}{H}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{S}{V}{I}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{S}{V}{B}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{S}{V}{M}{I}{N}                : make_token(length, TokenLine, TokenChars).
-{CSS_num}{S}{V}{M}{A}{X}                : make_token(length, TokenLine, TokenChars).
-{CSS_num}{L}{V}{W}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{L}{V}{H}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{L}{V}{I}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{L}{V}{B}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{L}{V}{M}{I}{N}                : make_token(length, TokenLine, TokenChars).
-{CSS_num}{L}{V}{M}{A}{X}                : make_token(length, TokenLine, TokenChars).
-{CSS_num}{D}{V}{W}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{D}{V}{H}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{D}{V}{I}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{D}{V}{B}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{D}{V}{M}{I}{N}                : make_token(length, TokenLine, TokenChars).
-{CSS_num}{D}{V}{M}{A}{X}                : make_token(length, TokenLine, TokenChars).
-{CSS_num}{C}{Q}{W}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{C}{Q}{H}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{C}{Q}{I}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{C}{Q}{B}                      : make_token(length, TokenLine, TokenChars).
-{CSS_num}{C}{Q}{M}{I}{N}                : make_token(length, TokenLine, TokenChars).
-{CSS_num}{C}{Q}{M}{A}{X}                : make_token(length, TokenLine, TokenChars).
-{CSS_num}{D}{E}{G}                      : make_token(angle, TokenLine, TokenChars).
-{CSS_num}{R}{A}{D}                      : make_token(angle, TokenLine, TokenChars).
-{CSS_num}{G}{R}{A}{D}                   : make_token(angle, TokenLine, TokenChars).
-{CSS_num}{T}{U}{R}{N}                   : make_token(angle, TokenLine, TokenChars).
-{CSS_num}{M}{S}                         : make_token(time, TokenLine, TokenChars).
-{CSS_num}{S}                            : make_token(time, TokenLine, TokenChars).
-{CSS_num}{H}{Z}                         : make_token(freq, TokenLine, TokenChars).
-{CSS_num}{K}{H}{Z}                      : make_token(freq, TokenLine, TokenChars).
-{CSS_num}{D}{P}{I}                      : make_token(resolution, TokenLine, TokenChars).
-{CSS_num}{D}{P}{C}{M}                   : make_token(resolution, TokenLine, TokenChars).
-{CSS_num}{D}{P}{P}{X}                   : make_token(resolution, TokenLine, TokenChars).
-{CSS_num}{X}                            : make_token(resolution, TokenLine, TokenChars).
-{CSS_num}{CSS_ident}                    : make_token(dimension, TokenLine, TokenChars).
+{CSS_num}{CSS_ident}                    : make_dimension_token(TokenLine, TokenChars).
 {CSS_num}%                              : make_token(percentage, TokenLine, TokenChars).
 {CSS_num}                               : make_token(number, TokenLine, TokenChars).
 [uU][rR][lL]\({CSS_w}{CSS_string}{CSS_w}\)       : make_token(uri, TokenLine, TokenChars).
@@ -176,6 +115,77 @@ Rules.
 
 
 Erlang code.
+
+make_dimension_token(Line, Chars) ->
+    {_Number, Unit} = lists:splitwith(fun is_num_char/1, Chars),
+    make_token(dimension_unit(string:to_lower(Unit)), Line, Chars).
+
+is_num_char(C) when C >= $0, C =< $9 -> true;
+is_num_char($.) -> true;
+is_num_char(_) -> false.
+
+dimension_unit("em") -> ems;
+dimension_unit("ex") -> exs;
+dimension_unit("cap") -> length;
+dimension_unit("ch") -> length;
+dimension_unit("ic") -> length;
+dimension_unit("lh") -> length;
+dimension_unit("rem") -> length;
+dimension_unit("rex") -> length;
+dimension_unit("rcap") -> length;
+dimension_unit("rch") -> length;
+dimension_unit("ric") -> length;
+dimension_unit("rlh") -> length;
+dimension_unit("px") -> length;
+dimension_unit("cm") -> length;
+dimension_unit("mm") -> length;
+dimension_unit("q") -> length;
+dimension_unit("in") -> length;
+dimension_unit("pt") -> length;
+dimension_unit("pc") -> length;
+dimension_unit("vw") -> length;
+dimension_unit("vh") -> length;
+dimension_unit("vi") -> length;
+dimension_unit("vb") -> length;
+dimension_unit("vmin") -> length;
+dimension_unit("vmax") -> length;
+dimension_unit("svw") -> length;
+dimension_unit("svh") -> length;
+dimension_unit("svi") -> length;
+dimension_unit("svb") -> length;
+dimension_unit("svmin") -> length;
+dimension_unit("svmax") -> length;
+dimension_unit("lvw") -> length;
+dimension_unit("lvh") -> length;
+dimension_unit("lvi") -> length;
+dimension_unit("lvb") -> length;
+dimension_unit("lvmin") -> length;
+dimension_unit("lvmax") -> length;
+dimension_unit("dvw") -> length;
+dimension_unit("dvh") -> length;
+dimension_unit("dvi") -> length;
+dimension_unit("dvb") -> length;
+dimension_unit("dvmin") -> length;
+dimension_unit("dvmax") -> length;
+dimension_unit("cqw") -> length;
+dimension_unit("cqh") -> length;
+dimension_unit("cqi") -> length;
+dimension_unit("cqb") -> length;
+dimension_unit("cqmin") -> length;
+dimension_unit("cqmax") -> length;
+dimension_unit("deg") -> angle;
+dimension_unit("rad") -> angle;
+dimension_unit("grad") -> angle;
+dimension_unit("turn") -> angle;
+dimension_unit("ms") -> time;
+dimension_unit("s") -> time;
+dimension_unit("hz") -> freq;
+dimension_unit("khz") -> freq;
+dimension_unit("dpi") -> resolution;
+dimension_unit("dpcm") -> resolution;
+dimension_unit("dppx") -> resolution;
+dimension_unit("x") -> resolution;
+dimension_unit(_) -> dimension.
 
 make_token(literal, Line, ";") -> {token, {';', Line, ";"}};
 make_token(literal, Line, "{") -> {token, {'{', Line, "{"}};

--- a/src/z_css_lexer.xrl
+++ b/src/z_css_lexer.xrl
@@ -95,11 +95,7 @@ Rules.
 
 #{CSS_name}                             : make_token(hash, TokenLine, TokenChars).
 
-@{I}{M}{P}{O}{R}{T}                     : make_token(import_sym, TokenLine, TokenChars).
-@{F}{O}{N}{T}-{F}{A}{C}{E}              : make_token(font_face_sym, TokenLine, TokenChars).
-@{P}{A}{G}{E}                           : make_token(page_sym, TokenLine, TokenChars).
-@{M}{E}{D}{I}{A}                        : make_token(media_sym, TokenLine, TokenChars).
-@{C}{H}{A}{R}{S}{E}{T}\s                : make_token(charset_sym, TokenLine, TokenChars).
+@{CSS_ident}                            : make_at_rule_token(TokenLine, TokenChars).
 
 !({w}|{CSS_comment})*{I}{M}{P}{O}{R}{T}{A}{N}{T}  : make_token(important_sym, TokenLine, TokenChars).
 
@@ -115,6 +111,17 @@ Rules.
 
 
 Erlang code.
+
+make_at_rule_token(Line, [$@ | Ident0] = Chars) ->
+    Ident = string:to_lower(css_unescape_ident(Ident0)),
+    make_token(at_rule(Ident), Line, Chars).
+
+at_rule("import") -> import_sym;
+at_rule("font-face") -> font_face_sym;
+at_rule("page") -> page_sym;
+at_rule("media") -> media_sym;
+at_rule("charset") -> charset_sym;
+at_rule(_) -> ident.
 
 make_dimension_token(Line, Chars) ->
     {_Number, Unit0} = lists:splitwith(fun is_num_char/1, Chars),
@@ -164,10 +171,6 @@ skip_css_ws([C|Rest]) when C =:= $\s; C =:= $\t; C =:= $\r; C =:= $\n; C =:= $\f
     Rest;
 skip_css_ws(Rest) ->
     Rest.
-
-is_num_char(C) when C >= $0, C =< $9 -> true;
-is_num_char($.) -> true;
-is_num_char(_) -> false.
 
 dimension_unit("em") -> ems;
 dimension_unit("ex") -> exs;

--- a/src/z_css_lexer.xrl
+++ b/src/z_css_lexer.xrl
@@ -138,6 +138,7 @@ css_unescape_ident(Unit) ->
 css_unescape_ident([], Acc) ->
     lists:reverse(Acc);
 css_unescape_ident([$\\, C | Rest], Acc) ->
+    case is_hex(C) of
         true ->
             {Hex, Rest1} = take_hex([C|Rest], 6, []),
             Codepoint0 = list_to_integer(Hex, 16),

--- a/src/z_css_lexer.xrl
+++ b/src/z_css_lexer.xrl
@@ -121,7 +121,7 @@ at_rule("font-face") -> font_face_sym;
 at_rule("page") -> page_sym;
 at_rule("media") -> media_sym;
 at_rule("charset") -> charset_sym;
-at_rule(_) -> ident.
+at_rule(_) -> bad_at_rule.
 
 make_dimension_token(Line, Chars) ->
     {_Number, Unit0} = lists:splitwith(fun is_num_char/1, Chars),

--- a/src/z_css_lexer.xrl
+++ b/src/z_css_lexer.xrl
@@ -117,8 +117,53 @@ Rules.
 Erlang code.
 
 make_dimension_token(Line, Chars) ->
-    {_Number, Unit} = lists:splitwith(fun is_num_char/1, Chars),
-    make_token(dimension_unit(string:to_lower(Unit)), Line, Chars).
+    {_Number, Unit0} = lists:splitwith(fun is_num_char/1, Chars),
+    Unit = string:to_lower(css_unescape_ident(Unit0)),
+    make_token(dimension_unit(Unit), Line, Chars).
+
+is_num_char(C) when C >= $0, C =< $9 -> true;
+is_num_char($.) -> true;
+is_num_char(_) -> false.
+
+css_unescape_ident(Unit) ->
+    css_unescape_ident(Unit, []).
+
+css_unescape_ident([], Acc) ->
+    lists:reverse(Acc);
+css_unescape_ident([$\\, C | Rest], Acc) ->
+    case is_hex(C) of
+        true ->
+            {Hex, Rest1} = take_hex([C|Rest], 6, []),
+            Codepoint = list_to_integer(Hex, 16),
+            Rest2 = skip_css_ws(Rest1),
+            css_unescape_ident(Rest2, [Codepoint | Acc]);
+        false ->
+            css_unescape_ident(Rest, [C | Acc])
+    end;
+css_unescape_ident([$\\], Acc) ->
+    lists:reverse([$\\ | Acc]);
+css_unescape_ident([C | Rest], Acc) ->
+    css_unescape_ident(Rest, [C | Acc]).
+
+is_hex(C) when C >= $0, C =< $9 -> true;
+is_hex(C) when C >= $a, C =< $f -> true;
+is_hex(C) when C >= $A, C =< $F -> true;
+is_hex(_) -> false.
+
+take_hex(Rest, 0, Acc) ->
+    {lists:reverse(Acc), Rest};
+take_hex([C|Rest], N, Acc) when N > 0 ->
+    case is_hex(C) of
+        true -> take_hex(Rest, N-1, [C|Acc]);
+        false -> {lists:reverse(Acc), [C|Rest]}
+    end;
+take_hex(Rest, _N, Acc) ->
+    {lists:reverse(Acc), Rest}.
+
+skip_css_ws([C|Rest]) when C =:= $\s; C =:= $\t; C =:= $\r; C =:= $\n; C =:= $\f ->
+    Rest;
+skip_css_ws(Rest) ->
+    Rest.
 
 is_num_char(C) when C >= $0, C =< $9 -> true;
 is_num_char($.) -> true;

--- a/src/z_css_lexer.xrl
+++ b/src/z_css_lexer.xrl
@@ -138,10 +138,15 @@ css_unescape_ident(Unit) ->
 css_unescape_ident([], Acc) ->
     lists:reverse(Acc);
 css_unescape_ident([$\\, C | Rest], Acc) ->
-    case is_hex(C) of
         true ->
             {Hex, Rest1} = take_hex([C|Rest], 6, []),
-            Codepoint = list_to_integer(Hex, 16),
+            Codepoint0 = list_to_integer(Hex, 16),
+            Codepoint = case Codepoint0 of
+                0 -> 16#FFFD;
+                C1 when C1 > 16#10FFFF -> 16#FFFD;
+                C1 when C1 >= 16#D800, C1 =< 16#DFFF -> 16#FFFD;
+                C1 -> C1
+            end,
             Rest2 = skip_css_ws(Rest1),
             css_unescape_ident(Rest2, [Codepoint | Acc]);
         false ->

--- a/src/z_css_parser.yrl
+++ b/src/z_css_parser.yrl
@@ -34,6 +34,12 @@ Nonterminals
     FontFace
     FontFaceBody
     FontFaceToken
+    BadAtRule
+    BadAtRulePrelude
+    BadAtRulePreludeToken
+    BadAtRuleBlock
+    BadAtRuleBody
+    BadAtRuleBodyToken
     Page
     DeclarationList
     Declaration
@@ -67,6 +73,7 @@ Terminals
     page_sym
     media_sym
     charset_sym
+    bad_at_rule
     important_sym
     ems
     exs
@@ -134,11 +141,13 @@ Rules -> '$empty'                         : [].
 Rules -> RuleSet Rules                    : ['$1' | '$2'].
 Rules -> Media Rules                      : ['$1' | '$2'].
 Rules -> FontFace Rules                   : '$2'.
+Rules -> BadAtRule Rules                  : ['$1' | '$2'].
 Rules -> Page Rules                       : ['$1' | '$2'].
 
 RuleSetList -> '$empty'                   : [].
 RuleSetList -> RuleSet RuleSetList        : ['$1' | '$2'].
 RuleSetList -> FontFace RuleSetList       : '$2'.
+RuleSetList -> BadAtRule RuleSetList      : ['$1' | '$2'].
 
 RuleSet -> SelectorList '{' DeclarationList '}' : {rule, '$1', '$3'}.
 
@@ -158,6 +167,7 @@ FontFaceToken -> import_sym                : '$1'.
 FontFaceToken -> page_sym                  : '$1'.
 FontFaceToken -> media_sym                 : '$1'.
 FontFaceToken -> charset_sym               : '$1'.
+FontFaceToken -> bad_at_rule               : '$1'.
 FontFaceToken -> important_sym             : '$1'.
 FontFaceToken -> ems                       : '$1'.
 FontFaceToken -> exs                       : '$1'.
@@ -186,6 +196,62 @@ FontFaceToken -> '='                       : '$1'.
 FontFaceToken -> '>'                       : '$1'.
 FontFaceToken -> '-'                       : '$1'.
 FontFaceToken -> '+'                       : '$1'.
+
+BadAtRule -> bad_at_rule BadAtRulePrelude ';'   : bad_at_rule.
+BadAtRule -> bad_at_rule BadAtRulePrelude BadAtRuleBlock : bad_at_rule.
+
+BadAtRulePrelude -> '$empty'                         : [].
+BadAtRulePrelude -> BadAtRulePreludeToken BadAtRulePrelude : ['$1' | '$2'].
+
+BadAtRuleBlock -> '{' BadAtRuleBody '}'              : [].
+
+BadAtRuleBody -> '$empty'                            : [].
+BadAtRuleBody -> BadAtRuleBodyToken BadAtRuleBody    : ['$1' | '$2'].
+BadAtRuleBody -> BadAtRuleBlock BadAtRuleBody        : '$2'.
+
+BadAtRulePreludeToken -> badcomment       : '$1'.
+BadAtRulePreludeToken -> includes         : '$1'.
+BadAtRulePreludeToken -> dashmatch        : '$1'.
+BadAtRulePreludeToken -> string           : '$1'.
+BadAtRulePreludeToken -> bad_string       : '$1'.
+BadAtRulePreludeToken -> ident            : '$1'.
+BadAtRulePreludeToken -> hash             : '$1'.
+BadAtRulePreludeToken -> import_sym       : '$1'.
+BadAtRulePreludeToken -> font_face_sym    : '$1'.
+BadAtRulePreludeToken -> page_sym         : '$1'.
+BadAtRulePreludeToken -> media_sym        : '$1'.
+BadAtRulePreludeToken -> charset_sym      : '$1'.
+BadAtRulePreludeToken -> bad_at_rule      : '$1'.
+BadAtRulePreludeToken -> important_sym    : '$1'.
+BadAtRulePreludeToken -> ems              : '$1'.
+BadAtRulePreludeToken -> exs              : '$1'.
+BadAtRulePreludeToken -> length           : '$1'.
+BadAtRulePreludeToken -> angle            : '$1'.
+BadAtRulePreludeToken -> time             : '$1'.
+BadAtRulePreludeToken -> freq             : '$1'.
+BadAtRulePreludeToken -> resolution       : '$1'.
+BadAtRulePreludeToken -> dimension        : '$1'.
+BadAtRulePreludeToken -> percentage       : '$1'.
+BadAtRulePreludeToken -> number           : '$1'.
+BadAtRulePreludeToken -> uri              : '$1'.
+BadAtRulePreludeToken -> bad_uri          : '$1'.
+BadAtRulePreludeToken -> function         : '$1'.
+BadAtRulePreludeToken -> '['              : '$1'.
+BadAtRulePreludeToken -> ']'              : '$1'.
+BadAtRulePreludeToken -> '('              : '$1'.
+BadAtRulePreludeToken -> ')'              : '$1'.
+BadAtRulePreludeToken -> ','              : '$1'.
+BadAtRulePreludeToken -> '.'              : '$1'.
+BadAtRulePreludeToken -> ':'              : '$1'.
+BadAtRulePreludeToken -> '*'              : '$1'.
+BadAtRulePreludeToken -> '/'              : '$1'.
+BadAtRulePreludeToken -> '='              : '$1'.
+BadAtRulePreludeToken -> '>'              : '$1'.
+BadAtRulePreludeToken -> '-'              : '$1'.
+BadAtRulePreludeToken -> '+'              : '$1'.
+
+BadAtRuleBodyToken -> BadAtRulePreludeToken : '$1'.
+BadAtRuleBodyToken -> ';'                   : '$1'.
 
 SelectorList -> Selector                    : ['$1'].
 SelectorList -> SelectorList ',' Selector   : '$1' ++ ['$3'].

--- a/test/z_css_test.erl
+++ b/test/z_css_test.erl
@@ -40,6 +40,17 @@ sanitize_external_references_test() ->
         {ok, <<"@media only screen and (max-width:600px) {\np {\ncolor:red;\n}\n}\n">>},
         z_css:sanitize(<<"@media only screen and (max-width: 600px) { @font-face { src: url(https://example.com/font.woff2); } p { color: red } }">>)).
 
+sanitize_bad_at_rule_test() ->
+    ?assertEqual(
+        {ok, <<"p {\ncolor:red;\n}\n">>},
+        z_css:sanitize(<<"@namespace svg url(https://example.com/svg); p { color: red }">>)),
+    ?assertEqual(
+        {ok, <<"p {\ncolor:blue;\n}\n">>},
+        z_css:sanitize(<<"@supports (display: grid) { p { background: url(https://example.com/x.png) } } p { color: blue }">>)),
+    ?assertEqual(
+        {ok, <<"@media screen {\np {\ncolor:red;\n}\n}\n">>},
+        z_css:sanitize(<<"@media screen { @s\\75 pports (display: grid) { p { background: url(https://example.com/x.png) } } p { color: red } }">>)).
+
 sanitize_content_test() ->
     ?assertEqual(
         {ok, <<":before {\ncontent:\"Hello &quot;\\&#39;world\";\n}\n">>},

--- a/test/z_css_test.erl
+++ b/test/z_css_test.erl
@@ -20,6 +20,9 @@ sanitize_media_test() ->
         {ok, <<"@media screen {\np {\nbackground:url();\n}\n}\n">>},
         z_css:sanitize(<<"@media screen {p{background:url(http://example.com)}}">>)),
     ?assertEqual(
+        {ok, <<"@media screen {\np {\ncolor:red;\n}\n}\n">>},
+        z_css:sanitize(<<"@m\\65 dia screen {p{color:red}}">>)),
+    ?assertEqual(
         {ok, <<"@media screen,print,foobar {\n}\n">>},
         z_css:sanitize(<<"@media screen,print,foobar { }">>)),
     ?assertEqual(
@@ -51,6 +54,9 @@ sanitize_unit_test() ->
     ?assertEqual(
         {ok,<<"a {\nc:100%;\nd:1em;\ne:2px;\nf:a,b,c;\n}\n">>},
         z_css:sanitize(<<"a {\nc:100%; d:1em; e:2px; f:a,b,c;\n}\n">>)),
+    ?assertEqual(
+        {ok,<<"a {\nb:1\\65 m;\nc:1\\70 x;\n}\n">>},
+        z_css:sanitize(<<"a { b: 1\\65 m; c: 1\\70 x; }">>)),
     Units = [
         <<"cap">>, <<"ch">>, <<"cm">>, <<"cqb">>, <<"cqh">>, <<"cqi">>, <<"cqmax">>, <<"cqmin">>, <<"cqw">>,
         <<"deg">>, <<"dpcm">>, <<"dpi">>, <<"dppx">>, <<"dvb">>, <<"dvh">>, <<"dvi">>, <<"dvmax">>,

--- a/test/z_css_test.erl
+++ b/test/z_css_test.erl
@@ -42,6 +42,11 @@ sanitize_content_test() ->
         {ok, <<":before {\ncontent:\"Hello &quot;\\&#39;world\";\n}\n">>},
         z_css:sanitize(<<":before { content: '<p>Hello \"\\'world' }">>)).
 
+sanitize_string_escape_test() ->
+    ?assertMatch(
+        {ok, _},
+        z_css:sanitize(<<":before { content: \"a\\|b\" }">>)).
+
 sanitize_unit_test() ->
     ?assertEqual(
         {ok,<<"a {\nc:100%;\nd:1em;\ne:2px;\nf:a,b,c;\n}\n">>},

--- a/test/z_css_test.erl
+++ b/test/z_css_test.erl
@@ -43,8 +43,8 @@ sanitize_content_test() ->
         z_css:sanitize(<<":before { content: '<p>Hello \"\\'world' }">>)).
 
 sanitize_string_escape_test() ->
-    ?assertMatch(
-        {ok, _},
+    ?assertEqual(
+        {ok, <<":before {\ncontent:\"a\\|b\";\n}\n">>},
         z_css:sanitize(<<":before { content: \"a\\|b\" }">>)).
 
 sanitize_unit_test() ->


### PR DESCRIPTION
This pull request refactors how CSS dimension tokens are parsed in the `z_css_lexer` by replacing a long list of explicit token rules with a more generic and maintainable approach. It introduces a function to dynamically determine the token type for dimension units, reducing code duplication and making it easier to support new units. Additionally, a minor fix is made to the newline character class, and a new test is added for string escape handling.

**Lexer refactoring and improvements:**

* Replaces the long list of explicit `{CSS_num}{UNIT}` token rules with a single rule using `make_dimension_token/2`, which determines the correct token type based on the unit (e.g., `em`, `px`, `deg`) at runtime, improving maintainability and extensibility.
* Implements the `make_dimension_token/2` function and supporting helpers (`is_num_char/1`, `dimension_unit/1`) to parse the unit and map it to the appropriate token type (such as `length`, `angle`, `time`, etc.).

**Bug fixes:**

* Fixes the definition of `CSS_nl` to correctly match newline characters by removing the unnecessary pipe character from the character class.

**Testing:**

* Adds a new unit test to verify that string escapes (such as `\|`) are properly handled in CSS content.