### PR TITLE
Add support for more Youtube metadata tags

### DIFF
--- a/src/z_url_metadata.erl
+++ b/src/z_url_metadata.erl
@@ -544,6 +544,11 @@ meta_tag(<<"description">>, Content, MD) -> [{description, Content}|MD];
 meta_tag(<<"author">>, Content, MD) -> [{author, Content}|MD];
 meta_tag(<<"thumbnail">>, Content, MD) -> [{thumbnail, Content}|MD];
 meta_tag(<<"content-type">>, Content, MD) -> [{content_type, Content}|MD];
+meta_tag(<<"duration">>, Content, MD) -> [{duration, Content}|MD];
+meta_tag(<<"datePublished">>, Content, MD) -> [{date_published, Content}|MD];
+meta_tag(<<"uploadDate">>, Content, MD) -> [{date_uploaded, Content}|MD];
+meta_tag(<<"embedUrl">>, Content, MD) -> [{embed_url, Content}|MD];
+meta_tag(<<"contentUrl">>, Content, MD) -> [{content_url, Content}|MD];
 meta_tag(_Name, _Content, MD) -> MD.
 
 meta_itemprop_tag(<<"name">>, Content, MD) -> meta_tag(<<"title">>, Content, MD);


### PR DESCRIPTION
This pull request adds support for extracting additional metadata fields from URLs in the `z_url_metadata.erl` module. The main changes are the handling of new meta tag types to enrich the metadata extracted from web pages.

**Metadata extraction enhancements:**

* Added support for the `duration` meta tag, mapping it to the `duration` field in the metadata.
* Added support for the `datePublished` meta tag, mapping it to the `date_published` field.
* Added support for the `uploadDate` meta tag, mapping it to the `date_uploaded` field.
* Added support for the `embedUrl` meta tag, mapping it to the `embed_url` field.
* Added support for the `contentUrl` meta tag, mapping it to the `content_url` field.