### PR TITLE
Fix: z_tempfile cleanup

### DIFF
--- a/src/z_tempfile.erl
+++ b/src/z_tempfile.erl
@@ -206,8 +206,8 @@ temppath() ->
 -spec cleanup() -> ok.
 cleanup() ->
     Old = calendar:datetime_to_gregorian_seconds( calendar:universal_time() ) - ?CLEANUP_SECS,
-    Tmp = filename:join(temppath(), <<"/ztmp-*">>),
-    Files = filelib:wildcard(Tmp),
+    Tmp = filename:join(z_tempfile:temppath(), <<"ztmp-*">>),
+    Files = filelib:wildcard(binary_to_list(Tmp)),
     lists:foreach(
         fun(F) ->
             case file:read_file_info(F, [ {time, universal} ]) of

--- a/src/z_tempfile.erl
+++ b/src/z_tempfile.erl
@@ -207,7 +207,7 @@ temppath() ->
 cleanup() ->
     Old = calendar:datetime_to_gregorian_seconds( calendar:universal_time() ) - ?CLEANUP_SECS,
     Tmp = filename:join(z_tempfile:temppath(), <<"ztmp-*">>),
-    Files = filelib:wildcard(binary_to_list(Tmp)),
+    Files = filelib:wildcard(unicode:characters_to_list(Tmp)),
     lists:foreach(
         fun(F) ->
             case file:read_file_info(F, [ {time, universal} ]) of


### PR DESCRIPTION
Not sure if this is a matter of erlang versions, but while trying the `z_tempfile:cleanup/0` function I've found that in my case:
1. with `/tmp` set as the `temppath/0`, the pattern match produced is `/ztmp-*` rather than the intended `/tmp/ztmp-*`
2. `filelib:wildcard/1` doesn't seem to like binary inputs, but works with lists