### PR TITLE
Fix an issue with ensure_dir

### DIFF
--- a/src/z_filelib.erl
+++ b/src/z_filelib.erl
@@ -99,7 +99,7 @@ is_relative(Path) ->
 
 
 first_missing([], Acc) ->
-    lists:reverse(Acc);
+    {lists:reverse(Acc), []};
 first_missing([P|Ps], Acc) ->
     Acc1 = [P|Acc],
     Path = filename:join(lists:reverse(Acc1)),

--- a/src/z_filelib.erl
+++ b/src/z_filelib.erl
@@ -99,7 +99,7 @@ is_relative(Path) ->
 
 
 first_missing([], Acc) ->
-    {lists:reverse(Acc), []};
+    {filename:join(lists:reverse(Acc)), []};
 first_missing([P|Ps], Acc) ->
     Acc1 = [P|Acc],
     Path = filename:join(lists:reverse(Acc1)),


### PR DESCRIPTION
This pull request makes a small change to the `first_missing/2` function in `src/z_filelib.erl` to alter its return value. Instead of returning just the reversed accumulator list when the input list is empty, it now returns a tuple containing the reversed accumulator and an empty list.

* [`src/z_filelib.erl`](diffhunk://#diff-1c11318441214bb33173c0c6cd10a82d97733017d044fa32366bca81715db289L102-R102): Modified the base case of `first_missing/2` to return `{lists:reverse(Acc), []}` instead of `lists:reverse(Acc)`.